### PR TITLE
Added python-pexpect to packages added in base._encrypt_device

### DIFF
--- a/fabulaws/ubuntu/instances/base.py
+++ b/fabulaws/ubuntu/instances/base.py
@@ -54,7 +54,7 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
         """
         if not passwd:
             passwd = getpass.getpass('Enter LUKS passphrase for cryptsetup: ')
-        self.install_packages(['cryptsetup'])
+        self.install_packages(['python-pexpect', 'cryptsetup'])
         crypt = 'crypt-{0}'.format(device.split('/')[-1])
         with hide('stdout'):
             answers = [


### PR DESCRIPTION
python-pexpect is not included in the 12.04 ami 
