### PR TITLE
Use security group ids

### DIFF
--- a/docs/initial-setup.rst
+++ b/docs/initial-setup.rst
@@ -37,10 +37,17 @@ project and updated in `fabulaws-config.yml`.
    * TCP port 6379 from myproject-web-sg
    * TCP port 6379 from myproject-worker-sg
 * **myproject-web-sg**
-   * TCP port 80 from amazon-elb-sg
-   * TCP port 443 from amazon-elb-sg
+  * For EC2-classic:
+    * TCP port 80 from amazon-elb-sg
+    * TCP port 443 from amazon-elb-sg
+  * For VPC-based AWS accounts:
+    * TCP port 80 from myproject-web-sg
+    * TCP port 443 from myproject-web-sg
 * **myproject-worker-sg**
    * (used only as a source - requires no additional firewall rules)
+* **myproject-incoming-web-sg**
+   * TCP port 80 from any address
+   * TCP port 443 from any address
 
 Load Balancer
 +++++++++++++
@@ -52,9 +59,14 @@ wildcard SSL certificate). Use the following parameters as a guide:
 
 * Choose a name and set it in ``fabulaws-config.yml``
 * Ports 80 and 443 should be mapped to 80 and 443 on the instances
-* Until FabulAWS is upgraded to support VPC, 'EC2-Classic' load balancers should
-  be used. Note that this will cause a warning to be shown when you try to 'Assign Security Groups'.
+* If on EC2-Classic (older AWS accounts), you can use 'EC2-Classic' load balancers.
+  Note that this will cause a warning to be shown when you try to 'Assign Security Groups'.
   That warning can be skipped.
+* If on newer, VPC-based AWS accounts:
+  * Add security group **myproject-incoming-web-sg** to the load balancer so
+    the load balancer can receive incoming requests.
+  * Add security group **myproject-web-sg** to the load balancer so the backend instances will
+    accept forwarded requests from the load balancer.
 * Setup an HTTPS health check on port 443 that monitors ``/healthcheck.html``
   at your desired frequency (you'll setup the health check URL in your app below)
 * Backend authentication and stickiness should be disabled

--- a/docs/sample_files/fabulaws-config.yaml
+++ b/docs/sample_files/fabulaws-config.yaml
@@ -145,11 +145,11 @@ instance_types:
 load_balancers:
   myproject:
     production:
-    - myproject-production-1
+    - myproject-production-lb
     staging:
-    - myproject-staging-1
+    - myproject-staging-lb
     testing:
-    - myproject-testing-1
+    - myproject-testing-lb
 
 # Mapping of Fabric environment names to AWS auto scaling group names. Auto
 # scaling groups can be configured in the AWS Management Console.

--- a/fabulaws/ec2.py
+++ b/fabulaws/ec2.py
@@ -120,6 +120,11 @@ class EC2Instance(object):
             self.conn = self._connect_ec2()
         self.elb_conn = self._connect_elb()
 
+    def get_security_group_ids(self):
+        if getattr(self, 'instance', False):
+            return [group.id for group in self.instance.groups]
+        return []
+
     def _connect_ec2(self):
         logger.debug('Connecting to EC2')
         return EC2Connection(self._key_id, self._secret)

--- a/fabulaws/ec2.py
+++ b/fabulaws/ec2.py
@@ -73,7 +73,7 @@ class EC2Instance(object):
     user = ''
     admin_groups = []
     instance_type = ''
-    security_groups = []
+    security_groups = []  # Names of the instance's security groups
     key_prefix = ''
     ssh_timeout = 5
 
@@ -120,10 +120,16 @@ class EC2Instance(object):
             self.conn = self._connect_ec2()
         self.elb_conn = self._connect_elb()
 
-    def get_security_group_ids(self):
-        if getattr(self, 'instance', False):
+    def get_security_groups_for_launch_configuration(self):
+        """
+        Return a list of the instance's security group identifiers in
+        the format needed for a launch configuration.  This is names for
+        EC-2 classic, and IDs for modern accounts.
+        """
+        if getattr(self, 'instance', False) and getattr(self.instance, 'vpc_id', False):
+            # It has a VPC so it's modern
             return [group.id for group in self.instance.groups]
-        return []
+        return self.security_groups
 
     def _connect_ec2(self):
         logger.debug('Connecting to EC2')

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1907,7 +1907,7 @@ def _create_launch_config(type_=None, server=None):
         lc = LaunchConfiguration(
             name=_instance_name('lc', timestamp, changeset),
             image_id=image.id,
-            security_groups=server.security_groups,
+            security_groups=server.get_security_group_ids(),
             instance_type=_find(env.instance_types, env.environment, 'web'),
         )
         AutoScaleConnection().create_launch_configuration(lc)

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1907,7 +1907,7 @@ def _create_launch_config(type_=None, server=None):
         lc = LaunchConfiguration(
             name=_instance_name('lc', timestamp, changeset),
             image_id=image.id,
-            security_groups=server.get_security_group_ids(),
+            security_groups=server.get_security_groups_for_launch_configuration(),
             instance_type=_find(env.instance_types, env.environment, 'web'),
         )
         AutoScaleConnection().create_launch_configuration(lc)


### PR DESCRIPTION
Apparent behavior change with VPC's.  Seem to need to
use security group IDs instead of names when creating
launch configuration.