### PR TITLE
Get fabsecrets from curdir

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import sys
 import time


### PR DESCRIPTION
With a previous bug leaving fabsecrets lying around
in the same dir as the file that imports fabsecrets,
need to force absolute imports to make sure we don't
accidentally import the wrong file.