### PR TITLE
Add 'florida' as a supported environment

### DIFF
--- a/fabulaws/library/wsgiautoscale/templates/newrelic.ini
+++ b/fabulaws/library/wsgiautoscale/templates/newrelic.ini
@@ -180,7 +180,7 @@ thread_profiler.enabled = true
 # override the common environment settings. The settings related to a
 # specific environment will be used when the environment argument to the
 # newrelic.agent.initialize() function has been defined to be either
-# "development", "test", "staging" or "production".
+# "development", "test", "staging", "florida", or "production".
 #
 
 [newrelic:development]
@@ -191,6 +191,9 @@ monitor_mode = false
 
 [newrelic:staging]
 app_name = Python Application (Staging)
+monitor_mode = true
+
+[newrelic:florida]
 monitor_mode = true
 
 [newrelic:production]


### PR DESCRIPTION
Should work the same as 'production'

It'd be better long-term for fabulaws to allow configuring the
environment name, but this should work for now.