### PR TITLE
Use separate secrets files for each environment

### DIFF
--- a/docs/initial-setup.rst
+++ b/docs/initial-setup.rst
@@ -131,10 +131,10 @@ Local passwords
 
 A number of passwords are required during deployment.  To reduce the number of
 prompts that need to be answered manually, you can use a file called
-``fabsecrets.py`` in the top level of your repository.
+``fabsecrets_<environment>.py`` in the top level of your repository.
 
 If you already have a server environment setup, run the following command to
-get a local copy of fabsecrets.py::
+get a local copy of fabsecrets_<environment>.py::
 
     fab <environment> update_local_fabsecrets
 
@@ -144,7 +144,7 @@ will be creating new servers, this must be obtained securely from another
 developer.
 
 If this is a brand-new project, you can use the following template for
-``fabsecrets.py``:
+``fabsecrets_<environment>.py``:
 
 .. literalinclude:: sample_files/fabsecrets.py
    :language: python
@@ -154,13 +154,13 @@ All of these are required to be filled in before any servers can be created.
 Remote passwords
 ++++++++++++++++
 
-To update passwords on the server, first retrieve a copy of ``fabsecrets.py``
+To update passwords on the server, first retrieve a copy of ``fabsecrets_<environment>.py``
 using the above command (or from another developer) and then run the following
 command::
 
     fab <environment> update_server_passwords
 
-**Note:** It's only necessary to have a copy of ``fabsecrets.py`` locally if you
+**Note:** It's only necessary to have a copy of ``fabsecrets_<environment>.py`` locally if you
 will be deploying new servers or updating the existing passwords on the
 servers.
 

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -29,12 +29,12 @@ To update the New Relic API and License keys, first find the new keys from
 the new account. The License Key can be found from the main account page, and
 the API key can be found via these instructions: https://docs.newrelic.com/docs/apis/api-key
 
-Next, make sure your local fabsecrets.py file is up to date::
+Next, make sure your local fabsecrets_<environment>.py file is up to date::
 
     fab production update_local_fabsecrets
 
 Next, update the ``newrelic_license_key`` and ``newrelic_api_key`` values
-inside the ``fabsecrets.py`` file with the new values. Then, update the keys
+inside the ``fabsecrets_<environment>.py`` file with the new values. Then, update the keys
 on the servers::
 
     fab staging update_server_passwords

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -20,6 +20,7 @@ from boto.exception import BotoServerError
 
 from fabric.api import (abort, cd, env, execute, hide, hosts, local, parallel,
     prompt, put, roles, require, run, runs_once, settings, sudo, task)
+from fabric.colors import red
 from fabric.contrib.files import exists, upload_template, append, uncomment, sed
 from fabric.network import disconnect_all
 
@@ -201,11 +202,12 @@ def _read_local_secrets():
             secrets_file = filename
             break
     else:
-        print("Warning: No secrets file found. Looked for %r" % secrets_files)
+        print(red("Warning: No secrets file found. Looked for %r" % secrets_files, bold=True))
         return None
     if secrets_file == 'fabsecrets.py':
-        print("Warning: Getting secrets from fabsecrets.py, which is deprecated. Secrets "
-              "should be in fabsecrets_{environment}.py.".format(environment=env.environment))
+        print(red("Warning: Getting secrets from fabsecrets.py, which is deprecated. Secrets "
+                  "should be in fabsecrets_{environment}.py.".format(environment=env.environment),
+                  bold=True))
     secrets = run_path(secrets_file)
     # run_path returns the globals dictionary, which includes things
     # like __file__, so strip those out.

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -8,6 +8,8 @@ import string
 import logging
 import datetime
 import multiprocessing
+from runpy import run_path
+
 import yaml
 
 from getpass import getpass
@@ -30,10 +32,6 @@ from .servers import (CacheInstance, DbMasterInstance,
     DbSlaveInstance, WebInstance, WorkerInstance,
     CombinedInstance)
 
-try:
-    import fabsecrets
-except ImportError:
-    fabsecrets = None
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -188,24 +186,63 @@ def _setup_env(deployment_tag=None, environment=None, override_servers={}):
     env.setdefault('syslog_server', False)
 
 
+def _read_local_secrets():
+    """
+    Return a dictionary with the secrets from the local secrets file, if any;
+    else returns None.
+    """
+    secrets_files = [
+        'fabsecrets_{environment}.py'.format(environment=env.environment),
+        'fabsecrets.py'
+    ]
+    secrets_file = None
+    for filename in secrets_files:
+        if os.path.exists(filename):
+            secrets_file = filename
+            break
+    else:
+        print("Warning: No secrets file found. Looked for %r" % secrets_files)
+        return None
+    if secrets_file == 'fabsecrets.py':
+        print("Warning: Getting secrets from fabsecrets.py, which is deprecated. Secrets "
+              "should be in fabsecrets_{environment}.py.".format(environment=env.environment))
+    secrets = run_path(secrets_file)
+    # run_path returns the globals dictionary, which includes things
+    # like __file__, so strip those out.
+    secrets = {k: secrets[k] for k in secrets if not k.startswith("__")}
+    return secrets
+
+
 def _random_password(length=8, chars=string.letters + string.digits):
     """Generates a random password with the specificed length and chars."""
     return ''.join([random.choice(chars) for i in range(length)])
 
 
-def _load_passwords(names, length=20, generate=False, ignore_local=False):
-    """Retrieve password from the user's home directory, or generate a new random one if none exists"""
+def _load_passwords(names, ignore_local=False):
+    """
+    Utility for working with secrets, maybe on a remote server.
+
+    It gets a value for each password: If there's a local secrets file and it
+    has a value for name and ignore_local is false, it uses the
+    value from the local secrets file; in all other cases, it gets
+    the value from the remote server.
+
+    Then it sets the password as an attribute on 'env'.  This is because template rendering
+    uses `env` as its context and all the templates expect the
+    passwords to be in the context.
+
+    :param names: Iterable of names to operate on
+    :param ignore_local: Whether to prefer the remote value even if there's a local value
+    """
+    if ignore_local:
+        fabsecrets = None
+    else:
+        fabsecrets = _read_local_secrets()
     for name in names:
         filename = ''.join([env.home, name])
         filename = os.path.join(env.home, name)
-        if generate:
-            passwd = _random_password(length=length)
-            sudo('touch %s' % filename, user=env.deploy_user)
-            sudo('chmod 600 %s' % filename, user=env.deploy_user)
-            with hide('running'):
-                sudo('echo "%s">%s' % (passwd, filename), user=env.deploy_user)
-        if fabsecrets and hasattr(fabsecrets, name) and not ignore_local:
-            passwd = getattr(fabsecrets, name)
+        if fabsecrets and name in fabsecrets and not ignore_local:
+            passwd = fabsecrets[name]
         elif env.host_string and exists(filename):
             with hide('stdout'):
                 passwd = sudo('cat %s' % filename).strip()
@@ -489,24 +526,29 @@ def vcs(cmd, args=None):
 @runs_once
 @roles('worker')
 def update_local_fabsecrets():
-    """ create or update the local fabsecrets.py file based on the passwords on the server """
+    """ create or update the local fabsecrets_<environment>.py file based on the passwords on the server """
 
     require('environment', provided_by=env.environments)
 
-    local_path = os.path.abspath('fabsecrets.py')
+    local_path = os.path.abspath('fabsecrets_{environment}.py'.format(environment=env.environment))
 
-    answer = prompt('Are you sure you want to destroy %s '
-                    'and replace it with a copy of the values from '
-                    'the worker on %s?'
-                    '' % (local_path, env.environment.upper()), default='n')
-    if answer != 'y':
-        abort('Aborted.')
+    if os.path.exists(local_path):
+        answer = prompt('Are you sure you want to destroy %s '
+                        'and replace it with a copy of the values from '
+                        'the worker on %s?'
+                        '' % (local_path, env.environment.upper()), default='n')
+        if answer != 'y':
+            abort('Aborted.')
+
+    # Get the secrets from the remote server, ignoring any local secrets since we want
+    # to replace them with the ones actually in use.
     _load_passwords(env.password_names, ignore_local=True)
     out = ''
     for p in env.password_names:
         out += '%s = "%s"\n' % (p, getattr(env, p))
     with open(local_path, 'w') as f:
         f.write(out)
+    print("Wrote passwords to %s" % local_path)
 
 
 @task


### PR DESCRIPTION
Fabulaws will look first for fabsecrets_<environment>.py.
If that doesn't exist, it'll look for fabsecrets.py, for
backward compatibility, but will issue a deprecation
warning if it ends up using fabsecrets.py.

update_local_fabsecrets will create or overwrite
fabsecrets_<environment>.py.

Fixes #43.