### PR TITLE
Fix basic auth

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -677,9 +677,7 @@ def upload_nginx_conf():
     if env.use_basic_auth.get(env.environment):
         (handle, tmpfile) = mkstemp()
         f = os.fdopen(handle, 'w')
-        chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-        salt = ''.join(random.choice(chars) for i in range(8))
-        cmd = ['openssl', 'passwd', '-apr1', '-salt', salt, env.basic_auth_password]
+        cmd = ['openssl', 'passwd', '-apr1', env.basic_auth_password]
         encrypted = subprocess.check_output(cmd)
         f.write(env.basic_auth_username + ":" + encrypted + "\n")
         f.close()

--- a/fabulaws/library/wsgiautoscale/templates/nginx.conf
+++ b/fabulaws/library/wsgiautoscale/templates/nginx.conf
@@ -25,7 +25,7 @@ server {
     error_log {{ log_dir }}/error.log;
 
     location / {
-        {% if use_basic_auth %}
+        {% if use_basic_auth.get(environment) %}
         auth_basic "Restricted";
         auth_basic_user_file "{{ passwdfile_path }}";
         {% endif %}

--- a/fabulaws/library/wsgiautoscale/templates/nginx.conf
+++ b/fabulaws/library/wsgiautoscale/templates/nginx.conf
@@ -28,6 +28,12 @@ server {
         {% if use_basic_auth.get(environment) %}
         auth_basic "Restricted";
         auth_basic_user_file "{{ passwdfile_path }}";
+
+        location = /healthcheck.html {
+            # Turn off basic auth for healthcheck
+            auth_basic "off";
+            proxy_pass http://django_server;
+        }
         {% endif %}
 
         # set the same header as AWS ELB so SecureRequiredMiddleware picks it up


### PR DESCRIPTION
The nginx template uses the presence of the `use_basic_auth` dictionary to decide whether to turn basic auth on or off. That dictionary is always present, so basic auth is always turned on.

The first commit tests for the value of the specified environment in that dictionary.
The second commit turns off basic auth for the healthcheck.