### PR TITLE
fix redis restart failure when fs_encrypt=true

### DIFF
--- a/fabulaws/ubuntu/packages/mongodb.py
+++ b/fabulaws/ubuntu/packages/mongodb.py
@@ -16,10 +16,10 @@ class MongoDbMixin(AptMixin):
     def mongodb_service(self, cmd):
         sudo('service mongodb {0}'.format(cmd))
 
-    def secure_directories(self, *args, **kwargs):
+    def bind_app_directories(self, *args, **kwargs):
         # make sure we stop first in case we're being moved to a secure directory
         self.mongodb_service('stop')
-        super(MongoDbMixin, self).secure_directories(*args, **kwargs)
+        super(MongoDbMixin, self).bind_app_directories(*args, **kwargs)
         self.mongodb_service('start')
 
 

--- a/fabulaws/ubuntu/packages/postgres.py
+++ b/fabulaws/ubuntu/packages/postgres.py
@@ -227,10 +227,10 @@ class PostgresMixin(AptMixin):
         sudo('{0}/pg_ctl -D {1} promote'.format(self.pg_bin, self.pg_data),
              user='postgres')
 
-    def secure_directories(self, *args, **kwargs):
+    def bind_app_directories(self, *args, **kwargs):
         # make sure we stop first in case we're being moved to a secure directory
         self.pg_cmd('stop', fail=False)
-        super(PostgresMixin, self).secure_directories(*args, **kwargs)
+        super(PostgresMixin, self).bind_app_directories(*args, **kwargs)
         self.pg_cmd('start', fail=False)
 
     def setup(self):

--- a/fabulaws/ubuntu/packages/rabbitmq.py
+++ b/fabulaws/ubuntu/packages/rabbitmq.py
@@ -20,12 +20,12 @@ class RabbitMqMixin(AptMixin):
     def rabbitmq_service(self, cmd):
         return sudo('service rabbitmq-server {0}'.format(cmd))
 
-    def secure_directories(self, *args, **kwargs):
+    def bind_app_directories(self, *args, **kwargs):
         tries = kwargs.pop('rabbitmq_tries', 10)
         sleep = kwargs.pop('rabbitmq_sleep', 2)
         # make sure we stop before proceeding in case we get moved to a secure directory
         self.rabbitmq_service('stop') 
-        super(RabbitMqMixin, self).secure_directories(*args, **kwargs)
+        super(RabbitMqMixin, self).bind_app_directories(*args, **kwargs)
         # try starting a number of times with warn_only=True, as rabbitmq
         # fails to restart occassionally for unknown reasons
         restarted = False

--- a/fabulaws/ubuntu/packages/redis.py
+++ b/fabulaws/ubuntu/packages/redis.py
@@ -45,10 +45,10 @@ class RedisMixin(AptMixin):
                   use_sudo=True)
         self.redis_service('restart')
 
-    def secure_directories(self, *args, **kwargs):
+    def bind_app_directories(self, *args, **kwargs):
         # make sure we stop first in case we're being moved to a secure directory
         self.redis_service('stop')
-        super(RedisMixin, self).secure_directories(*args, **kwargs)
+        super(RedisMixin, self).bind_app_directories(*args, **kwargs)
         self.redis_service('start')
 
     def setup(self):


### PR DESCRIPTION
In the earlier refactor a method name change was inadvertently not propagated to the appropriate package mixin classes. This changes makes sure redis, etc., are shutdown properly before moving directories to a new, encrypted file system.