### PR TITLE
add support for Ubuntu 16.04 (xenial)

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -185,7 +185,7 @@ def _setup_env(deployment_tag=None, environment=None, override_servers={}):
         env.all_databases.append(env.master_database)
     env.all_databases.extend(env.slave_databases)
     for i, db in enumerate(env.all_databases):
-        db.stunnel_port = 6432 + i
+        db.stunnel_port = 7432 + i
     env.db_settings = env.get('db_settings', {})
     env.setdefault('syslog_server', False)
     if 'production_environments' not in env:

--- a/fabulaws/ubuntu/instances/base.py
+++ b/fabulaws/ubuntu/instances/base.py
@@ -5,6 +5,8 @@ import logging
 
 import boto.exception
 
+from decimal import Decimal
+
 from fabric.api import *
 from fabric.contrib import files
 
@@ -155,6 +157,13 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
             vol.update()
         logger.debug('Deleting volume {0}'.format(vol.id))
         vol.delete()
+
+    @property
+    @uses_fabric
+    def ubuntu_release(self):
+        if not hasattr(self, '_ubuntu_release'):
+            self._ubuntu_release = Decimal(run('lsb_release -r -s').strip())
+        return self._ubuntu_release
 
     @uses_fabric
     def setup_mirror(self, mirror=None):

--- a/fabulaws/ubuntu/packages/base.py
+++ b/fabulaws/ubuntu/packages/base.py
@@ -45,8 +45,7 @@ class BaseAptMixin(object):
     def add_ppa(self, name):
         """Add personal package archive."""
 
-        release = Decimal(sudo(u"lsb_release -r").split(':')[1].strip())
-        if release >= Decimal('12.04'):
+        if self.ubuntu_release >= Decimal('12.04'):
             sudo(u"apt-add-repository -y %s" % name)
         else:
             sudo(u"apt-add-repository %s" % name)


### PR DESCRIPTION
* pgbouncer runs by default on 16.04 and uses port 6432, so we need to switch stunnel to use a different port (we don't use this pgbouncer, but it won't cause any harm other than the port conflict)
* fixed a bug in the naming of the `/etc/crypttab` entry (not sure why this didn't cause problems before)
* updated pip/virtualenv versions and removed no-op `update_meld3` method
* `npm` in Ubuntu 16.04 is recent enough, so just use that (also the `chris-lea` ppa doesn't include Xenial packages, yet at least)
* supervisor doesn't seem to start automatically after installation on 16.04, so it needs to be started manually