### PR TITLE
fix system reboots on 14.04 and 16.04 when fs_encrypt=True

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1280,21 +1280,20 @@ def mount_encrypted(drive_letter='f'):
     answer_sudo('cryptsetup luksOpen {device} {crypt}'
                 ''.format(device=device, crypt=crypt),
                 answers=answers)
-    sudo('sudo mount /dev/mapper/{0} /secure'.format(crypt))
     current_server = _current_server()
+    if exists(current_server.mount_script):
+        sudo(current_server.mount_script)
+    else:
+        abort('attempting to mount encrypted partitions, but mount script {} '
+              'does not exist'.format(current_server.mount_script))
     if exists(current_server.default_swap_file):
         sudo('swapon %s' % current_server.default_swap_file)
-    sudo('sudo mount -o bind /secure/home/secure /home/secure' % env)
-    sudo('sudo mount -o bind /secure/tmp /tmp')
     # if we're being created from an image, make sure the hostname gets updated
     upload_newrelic_sysmon_conf()
     if 'db-master' in _current_roles() or 'db-slave' in _current_roles():
-        sudo('sudo mount -o bind /secure/var/lib/postgresql /var/lib/postgresql')
         sudo('service postgresql start')
     if 'cache' in _current_roles():
-        sudo('sudo mount -o bind /secure/var/lib/redis /var/lib/redis')
         sudo('service redis-server start', pty=False)
-        sudo('sudo mount -o bind /secure/var/lib/rabbitmq /var/lib/rabbitmq')
         sudo('service rabbitmq-server start', pty=False)
         print '*** WARNING: While immediately restarting a cache server works as expected, '\
               'stopping and later restarting does not. For more information, see docs/servers/maintenance.rst ***'

--- a/fabulaws/ubuntu/instances/base.py
+++ b/fabulaws/ubuntu/instances/base.py
@@ -29,6 +29,7 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
     fs_type = 'ext3'
     fs_encrypt = False
     ubuntu_mirror = None
+    mount_script = '/mount-deferred.sh'
 
     def __init__(self, *args, **kwargs):
         self.volumes = []
@@ -76,6 +77,32 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
         return device
 
     @uses_fabric
+    def _mount_and_persist(self, device, mount_point, fs_type=None, opts=None):
+        mount_cmd = ' '.join([
+            'mount',
+            '-o {}'.format(opts) if opts else '',
+            '-t {}'.format(fs_type) if fs_type else '',
+            device,
+            mount_point,
+        ])
+        fstab_entry = ' '.join([
+            device,
+            mount_point,
+            fs_type if fs_type else self.fs_type,
+            opts if opts else 'defaults',
+            '0',
+            '0',
+        ])
+        sudo(mount_cmd)
+        if self.fs_encrypt:
+            if not files.exists(self.mount_script):
+                files.append(self.mount_script, "#!/bin/sh", use_sudo=True)
+                sudo('chmod a+x {}'.format(self.mount_script))
+            files.append(self.mount_script, mount_cmd, use_sudo=True)
+        else:
+            files.append('/etc/fstab', fstab_entry, use_sudo=True)
+
+    @uses_fabric
     def _format_volume(self, device, mount_point, passwd=None):
         """
         Creates an EBS volume of size ``vol_size``, manifests the device at
@@ -86,9 +113,7 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
             device = self._encrypt_device(device, passwd)
         sudo('mkfs.{0} {1}'.format(self.fs_type, device))
         sudo('mkdir {0}'.format(mount_point))
-        sudo('mount {0} {1}'.format(device, mount_point))
-        files.append('/etc/fstab', '{0} {1} {2} defaults 0 0'
-                     ''.format(device, mount_point, self.fs_type), use_sudo=True)
+        self._mount_and_persist(device, mount_point)
 
     def _set_volume_tags(self, vol, device, tags=None):
         if tags is None:
@@ -242,9 +267,7 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
             else:
                 sudo('mkdir -p {0}'.format(bound_app_dir))
             sudo('mkdir -p {0}'.format(app_dir))
-            sudo('mount -o bind {0} {1}'.format(bound_app_dir, app_dir))
-            files.append('/etc/fstab', '{0} {1} none bind 0 0'
-                         ''.format(bound_app_dir, app_dir), use_sudo=True)
+            self._mount_and_persist(bound_app_dir, app_dir, fs_type='none', opts='bind')
 
     def cleanup(self):
         """


### PR DESCRIPTION
If file system encryption is enabled, save mount points in a shell script rather than /etc/fstab (14.04 and 16.04 fail to boot otherwise).