### PR TITLE
fix healthcheck override when basic auth is enabled

### DIFF
--- a/fabulaws/library/wsgiautoscale/templates/nginx.conf
+++ b/fabulaws/library/wsgiautoscale/templates/nginx.conf
@@ -32,7 +32,9 @@ server {
         location = /healthcheck.html {
             # Turn off basic auth for healthcheck
             auth_basic "off";
-            proxy_pass http://django_server;
+            # Abbreviated version of logic below to serve healthcheck.html (override) if it exists
+            if (-f $request_filename) { break; }
+            if (!-f $request_filename) { proxy_pass http://django_server; break; }
         }
         {% endif %}
 


### PR DESCRIPTION
properly serve the healthcheck override (healthcheck.html) if it exists when basic auth is enabled