### PR TITLE
retry instance creation up to 3 times

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -578,7 +578,7 @@ def _create_many(servers):
 
 @task
 def new(deployment, environment, role, avail_zone=None, count=1):
-    _retry_new(deployment, environment, role, avail_zone, count)
+    _new(deployment, environment, role, avail_zone, count)
 
 
 def vcs(cmd, args=None):

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -469,8 +469,8 @@ def _new(deployment, environment, role, avail_zone=None, count=1, terminate_on_f
         try:
             server.setup()
         except:
-            logger.exception('server.setup() failed. tags=%s; terminate_on_failure=%s.'
-                             '' % (tags, terminate_on_failure))
+            logger.exception('server.setup() failed. tags=%s; terminate_on_failure=%s.',
+                             tags, terminate_on_failure)
             if terminate_on_failure:
                 server.terminate()
             raise
@@ -495,8 +495,8 @@ def _new(deployment, environment, role, avail_zone=None, count=1, terminate_on_f
             # allow overriding bootstrap command in project fabfile
             executel('bootstrap', hosts=env.roledefs[role])
     except:
-        logger.exception('server post-setup failed. tags=%s; terminate_on_failure=%s.'
-                         '' % (tags, terminate_on_failure))
+        logger.exception('server post-setup failed. tags=%s; terminate_on_failure=%s.',
+                         tags, terminate_on_failure)
         if terminate_on_failure:
             for server in servers:
                 server.terminate()
@@ -522,7 +522,7 @@ def _retry_new(*args, **kwargs):
     """
     tries = kwargs.pop('tries', 3)
     with settings(abort_exception=RetryFailure, abort_on_prompts=True):
-        for i in range(tries-1):
+        for i in range(tries - 1):
             try:
                 return _new(*args, terminate_on_failure=True, **kwargs)
             except RetryFailure:

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -507,6 +507,10 @@ def _new(deployment, environment, role, avail_zone=None, count=1, terminate_on_f
 
 
 def _retry_new(*args, **kwargs):
+    """
+    Retries instance creation up to three times (or ``tries``, if supplied).
+    Helps circumvent temporary network failures (e.g., while running apt-get).
+    """
     tries = kwargs.pop('tries', 3)
     class RetryFailure(Exception):
         pass

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -526,7 +526,7 @@ def _retry_new(*args, **kwargs):
             try:
                 return _new(*args, terminate_on_failure=True, **kwargs)
             except RetryFailure:
-                print '\n\n **** Server creation failed; retrying (attempt #%s)... ****\n\n' % i+2
+                print '\n\n **** Server creation failed; retrying (attempt #%s)... ****\n\n' % (i+2)
                 continue
     # if the last attempt is still going to fail, let it fail normally:
     return _new(*args, **kwargs)


### PR DESCRIPTION
Instance creation can fail for any number of temporary reasons, such as an apt repository network failure, an AWS API failure, or simply due to an unreliable instance that needs to be replaced. This PR attempts to circumvent that by retrying instance creation up to 3 times.