### PR TITLE
remove unneeded florida environment references

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -386,11 +386,6 @@ def staging(deployment_tag=env.default_deployment, answer=None): # support same 
 
 
 @task
-def florida(deployment_tag=env.default_deployment, answer=None): # support same args as production
-    _setup_env(deployment_tag, 'florida')
-
-
-@task
 def production(deployment_tag=env.default_deployment, answer=None):
     if answer is None:
         answer = prompt('Are you sure you want to activate the production '

--- a/fabulaws/library/wsgiautoscale/templates/newrelic.ini
+++ b/fabulaws/library/wsgiautoscale/templates/newrelic.ini
@@ -173,35 +173,7 @@ browser_monitoring.auto_instrument = true
 # call tree.
 thread_profiler.enabled = true
 
-# ---------------------------------------------------------------------------
-
-#
-# The application environments. These are specific settings which
-# override the common environment settings. The settings related to a
-# specific environment will be used when the environment argument to the
-# newrelic.agent.initialize() function has been defined to be either
-# "development", "test", "staging", "florida", or "production".
-#
-
 # Fix AttributeError: HTTPSConnection instance has no attribute '_nr_external_tracer'
 # https://discuss.newrelic.com/t/attributeerror-httpsconnection-instance-has-no-attribute--nr-external-tracer/15759/2
 [import-hook:http.client]
 enabled = false
-
-[newrelic:development]
-monitor_mode = false
-
-[newrelic:test]
-monitor_mode = false
-
-[newrelic:staging]
-app_name = Python Application (Staging)
-monitor_mode = true
-
-[newrelic:florida]
-monitor_mode = true
-
-[newrelic:production]
-monitor_mode = true
-
-# ---------------------------------------------------------------------------


### PR DESCRIPTION
Alternative environment names can be configured via env.environments and env.production_environments. I also removed the per-environment newrelic configuration altogether, since each environment gets its own `newrelic.ini` anyways.
