### PR TITLE
rewrite hosts that include a trailing dot in nginx to remove the dot

### DIFF
--- a/fabulaws/library/wsgiautoscale/templates/nginx.conf
+++ b/fabulaws/library/wsgiautoscale/templates/nginx.conf
@@ -47,6 +47,11 @@ server {
         proxy_read_timeout 30;
         proxy_connect_timeout 30;
 
+        # rewrite hosts with trailing dot to non-dot version
+        if ($http_host ~ "\.$" ){
+            rewrite ^(.*) $scheme://$host$1 permanent;
+        }
+
         # if the requested file exists in our document root, serve that above
         # all else (e.g., can be used to surve a 200 OK response for the health
         # check during system upgrades)


### PR DESCRIPTION
The trailing dot on domain names can complicate domain logic in Django, so it's easiest to redirect to the dot-less version of the TLD with Nginx so we don't have to worry about it.