### PR TITLE
don't specify datetime_format for awslogs

### DIFF
--- a/fabulaws/library/wsgiautoscale/templates/awslogs/awslogs.conf
+++ b/fabulaws/library/wsgiautoscale/templates/awslogs/awslogs.conf
@@ -118,6 +118,9 @@ state_file = /var/awslogs/state/agent-state
 #  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
 # ----------------------------------------------------------------------------------------------------------------------
 
+# We do not specify datetime_format for any log because incorrect formats may result in log messages getting skipped.
+# The behavior when datetime_format is not specified is to use the current time (when the log message is received by AWS).
+# See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html
 
 [/var/log/syslog]
 file = /var/log/syslog

--- a/fabulaws/library/wsgiautoscale/templates/awslogs/awslogs.conf
+++ b/fabulaws/library/wsgiautoscale/templates/awslogs/awslogs.conf
@@ -120,7 +120,6 @@ state_file = /var/awslogs/state/agent-state
 
 
 [/var/log/syslog]
-datetime_format = %b %d %H:%M:%S
 file = /var/log/syslog
 buffer_duration = 5000
 log_group_name = {{ deployment_tag }}-{{ environment }}-{{ current_role }}
@@ -128,7 +127,6 @@ log_stream_name = syslog
 initial_position = start_of_file
 
 [/var/log/kern.log]
-datetime_format = %b %d %H:%M:%S
 file = /var/log/kern.log
 buffer_duration = 5000
 log_group_name = {{ deployment_tag }}-{{ environment }}-{{ current_role }}
@@ -137,7 +135,6 @@ initial_position = start_of_file
 
 {% for tag, log_file, date_fmt in log_files %}
 [{{ log_file }}]
-datetime_format = {{ date_fmt }}
 file = {{ log_file }}
 buffer_duration = 5000
 log_group_name = {{ deployment_tag }}-{{ environment }}-{{ current_role }}


### PR DESCRIPTION
… because awslogs may skip log messages with datetime formats it doesn't recognize