### PR TITLE
Expose gunicorn --timeout and --worker-class options.

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -696,6 +696,7 @@ def upload_supervisor_conf(run_update=True):
     context = env.copy()
     cpu_count = int(run('cat /proc/cpuinfo|grep processor|wc -l'))
     context['timeout'] = int(getattr(env, 'gunicorn_timeout', 30))
+    context['worker_class'] = getattr(env, 'gunicorn_worker_class', 'sync')
     context['worker_count'] = cpu_count * int(getattr(env, 'gunicorn_worker_multiplier', 4))
     context['current_role'] = _current_roles()[0]
     _upload_template('supervisor.conf', destination, context=context,

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -695,6 +695,7 @@ def upload_supervisor_conf(run_update=True):
     destination = os.path.join(env.services, 'supervisor', '%(environment)s.conf' % env)
     context = env.copy()
     cpu_count = int(run('cat /proc/cpuinfo|grep processor|wc -l'))
+    context['timeout'] = int(getattr(env, 'gunicorn_timeout', 30))
     context['worker_count'] = cpu_count * int(getattr(env, 'gunicorn_worker_multiplier', 4))
     context['current_role'] = _current_roles()[0]
     _upload_template('supervisor.conf', destination, context=context,

--- a/fabulaws/library/wsgiautoscale/templates/supervisor.conf
+++ b/fabulaws/library/wsgiautoscale/templates/supervisor.conf
@@ -1,7 +1,7 @@
 {% if current_role == 'web' %}
 [program:{{ environment }}-server]
 process_name=%(program_name)s
-command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class=sync {{ wsgi_app }}
+command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class=sync {{ wsgi_app }} --timeout=120
 directory={{ code_root }}
 user={{ webserver_user }}
 autostart=true

--- a/fabulaws/library/wsgiautoscale/templates/supervisor.conf
+++ b/fabulaws/library/wsgiautoscale/templates/supervisor.conf
@@ -1,7 +1,7 @@
 {% if current_role == 'web' %}
 [program:{{ environment }}-server]
 process_name=%(program_name)s
-command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class=sync {{ wsgi_app }} --timeout={{ timeout }}
+command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class={{ worker_class }} {{ wsgi_app }} --timeout={{ timeout }}
 directory={{ code_root }}
 user={{ webserver_user }}
 autostart=true

--- a/fabulaws/library/wsgiautoscale/templates/supervisor.conf
+++ b/fabulaws/library/wsgiautoscale/templates/supervisor.conf
@@ -1,7 +1,7 @@
 {% if current_role == 'web' %}
 [program:{{ environment }}-server]
 process_name=%(program_name)s
-command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class=sync {{ wsgi_app }} --timeout=120
+command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class=sync {{ wsgi_app }} --timeout={{ timeout }}
 directory={{ code_root }}
 user={{ webserver_user }}
 autostart=true


### PR DESCRIPTION
One implication of allowing longer timeouts is the increased risk to DOS attacks; we may want to consider exposing a worker type setting at some point: http://docs.gunicorn.org/en/stable/design.html#choosing-a-worker-type