### PR TITLE
Python (pypi, pip, and virtualenv) updates

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -844,7 +844,7 @@ def update_requirements():
     # add HOME= so if there's an error, pip can save the log (Fabric doesn't
     # pass -H to sudo)
     cmd = ['HOME=%(home)s %(virtualenv_root)s/bin/pip install -q' % env]
-    cmd += [' --use-wheel']
+    cmd += [' --only-binary']
     if env.requirements_sdists:
         sdists = os.path.join(env.code_root, env.requirements_sdists)
         cmd += [' --no-index --find-links=file://%s' % sdists]

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -844,7 +844,7 @@ def update_requirements():
     # add HOME= so if there's an error, pip can save the log (Fabric doesn't
     # pass -H to sudo)
     cmd = ['HOME=%(home)s %(virtualenv_root)s/bin/pip install -q' % env]
-    cmd += [' --only-binary']
+    cmd += [' --only-binary :all:']
     if env.requirements_sdists:
         sdists = os.path.join(env.code_root, env.requirements_sdists)
         cmd += [' --no-index --find-links=file://%s' % sdists]

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -844,7 +844,6 @@ def update_requirements():
     # add HOME= so if there's an error, pip can save the log (Fabric doesn't
     # pass -H to sudo)
     cmd = ['HOME=%(home)s %(virtualenv_root)s/bin/pip install -q' % env]
-    cmd += [' --only-binary :all:']
     if env.requirements_sdists:
         sdists = os.path.join(env.code_root, env.requirements_sdists)
         cmd += [' --no-index --find-links=file://%s' % sdists]

--- a/fabulaws/library/wsgiautoscale/servers.py
+++ b/fabulaws/library/wsgiautoscale/servers.py
@@ -279,8 +279,8 @@ class AppMixin(PythonMixin):
     """
 
     python_packages = ['python2.7', 'python2.7-dev']
-    python_pip_version = '8.1.2'
-    python_virtualenv_version = '15.0.3'
+    python_pip_version = '9.0.3'
+    python_virtualenv_version = '15.2.0'
 
     @uses_fabric
     def install_less_and_yuglify(self):

--- a/fabulaws/ubuntu/packages/python.py
+++ b/fabulaws/ubuntu/packages/python.py
@@ -20,32 +20,14 @@ class PythonMixin(AptMixin):
     python_install_tools = True
     python_pip_version = None # install the latest version
     python_virtualenv_version = None # install the latest version
-    python_pypi_mirrors = [
-        'https://pypi.python.org',
-    ]
-
-    def _find_mirror(self):
-        """
-        Finds a PyPI mirror that appears to be online.
-        """
-
-        for mirror in self.python_pypi_mirrors:
-            try:
-                r = urllib2.urlopen(mirror)
-                if r.code == 200:
-                    return mirror
-            except urllib2.URLError:
-                pass
-        raise ValueError('No active mirror found.')
 
     @uses_fabric
     def install_python_tools(self):
         """
-        Installs the required Python tools from a random (hopefully online)
-        PyPI mirror.
+        Installs the required Python tools from PyPI.
         """
 
-        mirror = self._find_mirror()
+        mirror = 'https://pypi.python.org'
         version = ''
         if self.python_pip_version:
             version = '==%s' % self.python_pip_version


### PR DESCRIPTION
Now that there are no longer multiple PyPI mirrors, remove the logic that tried them until it found a working one.

Also, remove `--use-wheel` argument to `pip install` (deprecated since pip 7.0.0) and update to latest pip and virtualenv.

See also: #75 