### PR TITLE
Remove an assert that image is availalbe...

### DIFF
--- a/fabulaws/ec2.py
+++ b/fabulaws/ec2.py
@@ -387,7 +387,11 @@ class EC2Instance(object):
         logger.info('Waiting for image to enter "available" state...')
         while image.update() == 'pending':
             time.sleep(2)
-        assert image.update() == 'available'
+        status = image.update()
+        while status != 'available':
+            logger.info('Unexpected image status after pending: %s...waiting a bit longer...', status)
+            time.sleep(2)
+            status = image.update()
         logger.info('Image creation finished.')
         return image
 


### PR DESCRIPTION
...after state is no longer pending. This assertion has failed a few
times with debug prints indicating the status has briefly gone back
to "pending". So instead of asserting, wait for the status to be
available (and hope it stays that way).