### PR TITLE
Add CloudFormation stack to create a VPC with all required resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ boto==2.39.0
 pyyaml==3.11
 argyle==0.2.1
 awacs==0.5.4
-troposphere==1.9.6
+troposphere==2.6.1
 flake8==3.4.1
 isort==4.2.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ fabric==1.10.2
 boto==2.39.0
 pyyaml==3.11
 argyle==0.2.1
+awacs==0.5.4
+troposphere==1.9.6
+flake8==3.4.1
+isort==4.2.15

--- a/vpc-template/Makefile
+++ b/vpc-template/Makefile
@@ -1,0 +1,8 @@
+.DEFAULT_GOAL := vpc
+
+check:
+	flake8 stack/
+	isort --recursive --check-only --diff stack/
+
+vpc:
+	python -c 'import stack' > cloudformation-vpc-template.json

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -264,20 +264,20 @@
                 ]
             }
         },
-        "LoadBalancerProductionDNSName": {
+        "ElbProductionDnsName": {
             "Description": "Loadbalancer DNS",
             "Value": {
                 "Fn::GetAtt": [
-                    "LoadBalancerProduction",
+                    "ElbProduction",
                     "DNSName"
                 ]
             }
         },
-        "LoadBalancerStagingDNSName": {
+        "ElbStagingDnsName": {
             "Description": "Loadbalancer DNS",
             "Value": {
                 "Fn::GetAtt": [
-                    "LoadBalancerStaging",
+                    "ElbStaging",
                     "DNSName"
                 ]
             }
@@ -703,7 +703,7 @@
                 },
                 "LoadBalancerNames": [
                     {
-                        "Ref": "LoadBalancerProduction"
+                        "Ref": "ElbProduction"
                     }
                 ],
                 "MaxSize": "32",
@@ -745,7 +745,7 @@
                 },
                 "LoadBalancerNames": [
                     {
-                        "Ref": "LoadBalancerStaging"
+                        "Ref": "ElbStaging"
                     }
                 ],
                 "MaxSize": "32",
@@ -824,55 +824,7 @@
             },
             "Type": "AWS::EC2::SecurityGroupIngress"
         },
-        "GatewayAttachement": {
-            "Properties": {
-                "InternetGatewayId": {
-                    "Ref": "InternetGateway"
-                },
-                "VpcId": {
-                    "Ref": "Vpc"
-                }
-            },
-            "Type": "AWS::EC2::VPCGatewayAttachment"
-        },
-        "InternetGateway": {
-            "Type": "AWS::EC2::InternetGateway"
-        },
-        "LaunchConfigurationProduction": {
-            "Properties": {
-                "ImageId": {
-                    "Ref": "RouterAMI"
-                },
-                "InstanceType": "t2.nano",
-                "KeyName": {
-                    "Ref": "KeyName"
-                },
-                "SecurityGroups": [
-                    {
-                        "Ref": "WebServerSecurityGroup"
-                    }
-                ]
-            },
-            "Type": "AWS::AutoScaling::LaunchConfiguration"
-        },
-        "LaunchConfigurationStaging": {
-            "Properties": {
-                "ImageId": {
-                    "Ref": "RouterAMI"
-                },
-                "InstanceType": "t2.nano",
-                "KeyName": {
-                    "Ref": "KeyName"
-                },
-                "SecurityGroups": [
-                    {
-                        "Ref": "WebServerSecurityGroup"
-                    }
-                ]
-            },
-            "Type": "AWS::AutoScaling::LaunchConfiguration"
-        },
-        "LoadBalancerProduction": {
+        "ElbProduction": {
             "Properties": {
                 "CrossZone": "true",
                 "HealthCheck": {
@@ -952,7 +904,7 @@
             },
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
         },
-        "LoadBalancerStaging": {
+        "ElbStaging": {
             "Properties": {
                 "CrossZone": "true",
                 "HealthCheck": {
@@ -1031,6 +983,54 @@
                 ]
             },
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "GatewayAttachement": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "LaunchConfigurationProduction": {
+            "Properties": {
+                "ImageId": {
+                    "Ref": "RouterAMI"
+                },
+                "InstanceType": "t2.nano",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "WebServerSecurityGroup"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "LaunchConfigurationStaging": {
+            "Properties": {
+                "ImageId": {
+                    "Ref": "RouterAMI"
+                },
+                "InstanceType": "t2.nano",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "WebServerSecurityGroup"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
         },
         "LogGroup": {
             "DeletionPolicy": "Retain",

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -696,7 +696,6 @@
         },
         "AutoScalingGroupProduction": {
             "Properties": {
-                "DesiredCapacity": "0",
                 "HealthCheckGracePeriod": 300,
                 "HealthCheckType": "EC2",
                 "LaunchConfigurationName": {
@@ -739,7 +738,6 @@
         },
         "AutoScalingGroupStaging": {
             "Properties": {
-                "DesiredCapacity": "0",
                 "HealthCheckGracePeriod": 300,
                 "HealthCheckType": "EC2",
                 "LaunchConfigurationName": {
@@ -909,11 +907,11 @@
                         "Protocol": "HTTP"
                     },
                     {
-                        "InstancePort": 80,
+                        "InstancePort": 443,
                         "InstanceProtocol": {
                             "Fn::If": [
                                 "AcmCertConditionProduction",
-                                "HTTP",
+                                "HTTPS",
                                 "TCP"
                             ]
                         },
@@ -989,11 +987,11 @@
                         "Protocol": "HTTP"
                     },
                     {
-                        "InstancePort": 80,
+                        "InstancePort": 443,
                         "InstanceProtocol": {
                             "Fn::If": [
                                 "AcmCertConditionStaging",
-                                "HTTP",
+                                "HTTPS",
                                 "TCP"
                             ]
                         },

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -151,6 +151,7 @@
                     },
                     "Parameters": [
                         "WebWorkerHealthCheck",
+                        "ElbAccountID",
                         "AcmCertArnStaging",
                         "AcmCertArnProduction"
                     ]
@@ -216,6 +217,9 @@
                 },
                 "DomainNameAlternates": {
                     "default": "Alternate Domain Names"
+                },
+                "ElbAccountID": {
+                    "default": "Elastic Load Balancing Account ID"
                 },
                 "KeyName": {
                     "default": "SSH Key Name"
@@ -288,6 +292,42 @@
             "Value": {
                 "Fn::GetAtt": [
                     "AssetsDistributionStaging",
+                    "DomainName"
+                ]
+            }
+        },
+        "BackupsBucketProductionDomainName": {
+            "Description": "Backups bucket domain name (production)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "BackupsBucketProduction",
+                    "DomainName"
+                ]
+            }
+        },
+        "BackupsBucketStagingDomainName": {
+            "Description": "Backups bucket domain name (staging)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "BackupsBucketStaging",
+                    "DomainName"
+                ]
+            }
+        },
+        "ElbLogsBucketProductionDomainName": {
+            "Description": "ElbLogs bucket domain name (production)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "ElbLogsBucketProduction",
+                    "DomainName"
+                ]
+            }
+        },
+        "ElbLogsBucketStagingDomainName": {
+            "Description": "ElbLogs bucket domain name (staging)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "ElbLogsBucketStaging",
                     "DomainName"
                 ]
             }
@@ -388,6 +428,11 @@
         "DomainNameAlternates": {
             "Description": "A comma-separated list of Alternate FQDNs.",
             "Type": "CommaDelimitedList"
+        },
+        "ElbAccountID": {
+            "Default": "",
+            "Description": "AWS account ID for ELBs for your region. See: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html",
+            "Type": "String"
         },
         "KeyName": {
             "ConstraintDescription": "must be the name of an existing EC2 KeyPair.",
@@ -955,8 +1000,247 @@
             },
             "Type": "AWS::EC2::SecurityGroupIngress"
         },
+        "BackupsBucketProduction": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "BackupsBucketStaging": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "ElbLogsBucketPolicyProduction": {
+            "Properties": {
+                "Bucket": {
+                    "Ref": "ElbLogsBucketProduction"
+                },
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "s3:PutObject",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:iam::",
+                                            {
+                                                "Ref": "ElbAccountID"
+                                            },
+                                            ":root"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        {
+                                            "Fn::If": [
+                                                "InGovCloudRegion",
+                                                "arn:aws-us-gov",
+                                                "arn:aws"
+                                            ]
+                                        },
+                                        ":s3:::",
+                                        {
+                                            "Ref": "ElbLogsBucketProduction"
+                                        },
+                                        "/*"
+                                    ]
+                                ]
+                            }
+                        }
+                    ],
+                    "Version": "2012-10-17"
+                }
+            },
+            "Type": "AWS::S3::BucketPolicy"
+        },
+        "ElbLogsBucketPolicyStaging": {
+            "Properties": {
+                "Bucket": {
+                    "Ref": "ElbLogsBucketStaging"
+                },
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "s3:PutObject",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:iam::",
+                                            {
+                                                "Ref": "ElbAccountID"
+                                            },
+                                            ":root"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "Resource": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        {
+                                            "Fn::If": [
+                                                "InGovCloudRegion",
+                                                "arn:aws-us-gov",
+                                                "arn:aws"
+                                            ]
+                                        },
+                                        ":s3:::",
+                                        {
+                                            "Ref": "ElbLogsBucketStaging"
+                                        },
+                                        "/*"
+                                    ]
+                                ]
+                            }
+                        }
+                    ],
+                    "Version": "2012-10-17"
+                }
+            },
+            "Type": "AWS::S3::BucketPolicy"
+        },
+        "ElbLogsBucketProduction": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "ElbLogsBucketStaging": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
         "ElbProduction": {
             "Properties": {
+                "AccessLoggingPolicy": {
+                    "EmitInterval": 60,
+                    "Enabled": true,
+                    "S3BucketName": {
+                        "Ref": "ElbLogsBucketProduction"
+                    }
+                },
                 "CrossZone": "true",
                 "HealthCheck": {
                     "HealthyThreshold": "2",
@@ -1037,6 +1321,13 @@
         },
         "ElbStaging": {
             "Properties": {
+                "AccessLoggingPolicy": {
+                    "EmitInterval": 60,
+                    "Enabled": true,
+                    "S3BucketName": {
+                        "Ref": "ElbLogsBucketStaging"
+                    }
+                },
                 "CrossZone": "true",
                 "HealthCheck": {
                     "HealthyThreshold": "2",

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -180,7 +180,9 @@
                     },
                     "Parameters": [
                         "RouterAMI",
-                        "KeyName"
+                        "KeyName",
+                        "AutoscalingTargetCPU",
+                        "AutoscalingNotificationsArn"
                     ]
                 }
             ],
@@ -202,6 +204,12 @@
                 },
                 "AssetsUseCloudFront": {
                     "default": "Enable CloudFront"
+                },
+                "AutoscalingNotificationsArn": {
+                    "default": "Autoscaling Notifications ARN"
+                },
+                "AutoscalingTargetCPU": {
+                    "default": "Autoscaling Target CPU"
                 },
                 "DomainName": {
                     "default": "Domain Name"
@@ -364,6 +372,14 @@
             "Default": "true",
             "Description": "Whether or not to create a CloudFront distribution tied to the S3 assets bucket.",
             "Type": "String"
+        },
+        "AutoscalingNotificationsArn": {
+            "Description": "ARN of SNS topic to receive autoscaling notifications",
+            "Type": "String"
+        },
+        "AutoscalingTargetCPU": {
+            "Description": "Target CPU utilization for the autoscaling group (e.g., \"40.0\" for 40%).",
+            "Type": "Number"
         },
         "DomainName": {
             "Description": "The fully-qualified domain name for the application.",
@@ -751,7 +767,7 @@
         },
         "AutoScalingGroupProduction": {
             "Properties": {
-                "HealthCheckGracePeriod": 300,
+                "HealthCheckGracePeriod": 120,
                 "HealthCheckType": "ELB",
                 "LaunchConfigurationName": {
                     "Ref": "LaunchConfigurationProduction"
@@ -763,6 +779,19 @@
                 ],
                 "MaxSize": "32",
                 "MinSize": "0",
+                "NotificationConfigurations": [
+                    {
+                        "NotificationTypes": [
+                            "autoscaling:EC2_INSTANCE_LAUNCH",
+                            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+                            "autoscaling:EC2_INSTANCE_TERMINATE",
+                            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
+                        ],
+                        "TopicARN": {
+                            "Ref": "AutoscalingNotificationsArn"
+                        }
+                    }
+                ],
                 "Tags": [
                     {
                         "Key": "Name",
@@ -791,9 +820,26 @@
             },
             "Type": "AWS::AutoScaling::AutoScalingGroup"
         },
+        "AutoScalingGroupProductionScalingPolicy": {
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "AutoScalingGroupProduction"
+                },
+                "PolicyType": "TargetTrackingScaling",
+                "TargetTrackingConfiguration": {
+                    "PredefinedMetricSpecification": {
+                        "PredefinedMetricType": "ASGAverageCPUUtilization"
+                    },
+                    "TargetValue": {
+                        "Ref": "AutoscalingTargetCPU"
+                    }
+                }
+            },
+            "Type": "AWS::AutoScaling::ScalingPolicy"
+        },
         "AutoScalingGroupStaging": {
             "Properties": {
-                "HealthCheckGracePeriod": 300,
+                "HealthCheckGracePeriod": 120,
                 "HealthCheckType": "ELB",
                 "LaunchConfigurationName": {
                     "Ref": "LaunchConfigurationStaging"
@@ -805,6 +851,19 @@
                 ],
                 "MaxSize": "32",
                 "MinSize": "0",
+                "NotificationConfigurations": [
+                    {
+                        "NotificationTypes": [
+                            "autoscaling:EC2_INSTANCE_LAUNCH",
+                            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+                            "autoscaling:EC2_INSTANCE_TERMINATE",
+                            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
+                        ],
+                        "TopicARN": {
+                            "Ref": "AutoscalingNotificationsArn"
+                        }
+                    }
+                ],
                 "Tags": [
                     {
                         "Key": "Name",
@@ -832,6 +891,23 @@
                 ]
             },
             "Type": "AWS::AutoScaling::AutoScalingGroup"
+        },
+        "AutoScalingGroupStagingScalingPolicy": {
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "AutoScalingGroupStaging"
+                },
+                "PolicyType": "TargetTrackingScaling",
+                "TargetTrackingConfiguration": {
+                    "PredefinedMetricSpecification": {
+                        "PredefinedMetricType": "ASGAverageCPUUtilization"
+                    },
+                    "TargetValue": {
+                        "Ref": "AutoscalingTargetCPU"
+                    }
+                }
+            },
+            "Type": "AWS::AutoScaling::ScalingPolicy"
         },
         "AwsElbSecurityGroup": {
             "Properties": {

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -283,42 +283,6 @@
                 ]
             }
         },
-        "BackupsBucketProductionDomainName": {
-            "Description": "Backups bucket domain name (production)",
-            "Value": {
-                "Fn::GetAtt": [
-                    "BackupsBucketProduction",
-                    "DomainName"
-                ]
-            }
-        },
-        "BackupsBucketStagingDomainName": {
-            "Description": "Backups bucket domain name (staging)",
-            "Value": {
-                "Fn::GetAtt": [
-                    "BackupsBucketStaging",
-                    "DomainName"
-                ]
-            }
-        },
-        "ElbLogsBucketProductionDomainName": {
-            "Description": "ElbLogs bucket domain name (production)",
-            "Value": {
-                "Fn::GetAtt": [
-                    "ElbLogsBucketProduction",
-                    "DomainName"
-                ]
-            }
-        },
-        "ElbLogsBucketStagingDomainName": {
-            "Description": "ElbLogs bucket domain name (staging)",
-            "Value": {
-                "Fn::GetAtt": [
-                    "ElbLogsBucketStaging",
-                    "DomainName"
-                ]
-            }
-        },
         "ElbProductionDnsName": {
             "Description": "Loadbalancer DNS",
             "Value": {
@@ -988,6 +952,12 @@
                         ]
                     }
                 },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "ProductionBackups"
+                },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
                     "BlockPublicPolicy": "true",
@@ -1004,6 +974,45 @@
             "DeletionPolicy": "Retain",
             "Properties": {
                 "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "StagingBackups"
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "BucketLogsBucket": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "LogDeliveryWrite",
                 "BucketEncryption": {
                     "ServerSideEncryptionConfiguration": {
                         "Fn::If": [
@@ -1154,6 +1163,12 @@
                         ]
                     }
                 },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "ProductionElbLogs"
+                },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
                     "BlockPublicPolicy": "true",
@@ -1186,6 +1201,12 @@
                             ]
                         ]
                     }
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "StagingElbLogs"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
@@ -1505,6 +1526,12 @@
                         }
                     ]
                 },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "ProductionPrivate"
+                },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
                     "BlockPublicPolicy": "true",
@@ -1573,6 +1600,12 @@
                             }
                         }
                     ]
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "StagingPrivate"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -386,7 +386,7 @@
         "AssetsBucketProduction": {
             "DeletionPolicy": "Retain",
             "Properties": {
-                "AccessControl": "PublicRead",
+                "AccessControl": "Private",
                 "BucketEncryption": {
                     "ServerSideEncryptionConfiguration": {
                         "Fn::If": [
@@ -459,7 +459,7 @@
         "AssetsBucketStaging": {
             "DeletionPolicy": "Retain",
             "Properties": {
-                "AccessControl": "PublicRead",
+                "AccessControl": "Private",
                 "BucketEncryption": {
                     "ServerSideEncryptionConfiguration": {
                         "Fn::If": [
@@ -1155,7 +1155,10 @@
                     ]
                 },
                 "PublicAccessBlockConfiguration": {
-                    "IgnorePublicAcls": "true"
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
                 },
                 "VersioningConfiguration": {
                     "Status": "Enabled"
@@ -1231,7 +1234,10 @@
                     ]
                 },
                 "PublicAccessBlockConfiguration": {
-                    "IgnorePublicAcls": "true"
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
                 },
                 "VersioningConfiguration": {
                     "Status": "Enabled"

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -137,7 +137,12 @@
                         "DomainName",
                         "DomainNameAlternates",
                         "PrimaryAZ",
-                        "SecondaryAZ"
+                        "SecondaryAZ",
+                        "VpcCidr",
+                        "PublicSubnetACidr",
+                        "PublicSubnetBCidr",
+                        "PrivateSubnetACidr",
+                        "PrivateSubnetBCidr"
                     ]
                 },
                 {
@@ -213,11 +218,26 @@
                 "PrimaryAZ": {
                     "default": "Primary Availability Zone"
                 },
+                "PrivateSubnetACidr": {
+                    "default": "Private Subnet A CIDR Block"
+                },
+                "PrivateSubnetBCidr": {
+                    "default": "Private Subnet B CIDR Block"
+                },
+                "PublicSubnetACidr": {
+                    "default": "Public Subnet A CIDR Block"
+                },
+                "PublicSubnetBCidr": {
+                    "default": "Public Subnet B CIDR Block"
+                },
                 "RouterAMI": {
                     "default": "Router AMI"
                 },
                 "SecondaryAZ": {
                     "default": "Secondary Availability Zone"
+                },
+                "VpcCidr": {
+                    "default": "VPC IPv4 CIDR Block"
                 },
                 "WebWorkerHealthCheck": {
                     "default": "Health Check URL"
@@ -367,6 +387,34 @@
             "Description": "The primary availability zone for creating resources.",
             "Type": "AWS::EC2::AvailabilityZone::Name"
         },
+        "PrivateSubnetACidr": {
+            "AllowedPattern": "^((10\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)|(172\\.(1[6-9]|2[0-9]|3[0-1])\\.)|192\\.168\\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "Must be a private IPv4 range with size /16 and /28.",
+            "Default": "10.0.8.0/22",
+            "Description": "IPv4 CIDR block for the private subnet in the primary AZ. [Possibly not modifiable after stack creation]",
+            "Type": "String"
+        },
+        "PrivateSubnetBCidr": {
+            "AllowedPattern": "^((10\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)|(172\\.(1[6-9]|2[0-9]|3[0-1])\\.)|192\\.168\\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "Must be a private IPv4 range with size /16 and /28.",
+            "Default": "10.0.12.0/22",
+            "Description": "IPv4 CIDR block for the private subnet in the secondary AZ. [Possibly not modifiable after stack creation]",
+            "Type": "String"
+        },
+        "PublicSubnetACidr": {
+            "AllowedPattern": "^((10\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)|(172\\.(1[6-9]|2[0-9]|3[0-1])\\.)|192\\.168\\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "Must be a private IPv4 range with size /16 and /28.",
+            "Default": "10.0.0.0/22",
+            "Description": "IPv4 CIDR block for the public subnet in the primary AZ. [Possibly not modifiable after stack creation]",
+            "Type": "String"
+        },
+        "PublicSubnetBCidr": {
+            "AllowedPattern": "^((10\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)|(172\\.(1[6-9]|2[0-9]|3[0-1])\\.)|192\\.168\\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "Must be a private IPv4 range with size /16 and /28.",
+            "Default": "10.0.4.0/22",
+            "Description": "IPv4 CIDR block for the public subnet in the secondary AZ. [Possibly not modifiable after stack creation]",
+            "Type": "String"
+        },
         "RouterAMI": {
             "Default": "ami-089c333c4d9b09ffc",
             "Description": "pfSense AMI from the AWS marketplace in the same region as this stack",
@@ -375,6 +423,13 @@
         "SecondaryAZ": {
             "Description": "The secondary availability zone for creating resources. Must differ from primary zone.",
             "Type": "AWS::EC2::AvailabilityZone::Name"
+        },
+        "VpcCidr": {
+            "AllowedPattern": "^((10\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)|(172\\.(1[6-9]|2[0-9]|3[0-1])\\.)|192\\.168\\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.)([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "Must be a private IPv4 range with size /16 and /28.",
+            "Default": "10.0.0.0/20",
+            "Description": "The primary IPv4 CIDR block for the VPC. [Possibly not modifiable after stack creation]",
+            "Type": "String"
         },
         "WebWorkerHealthCheck": {
             "Default": "",
@@ -727,10 +782,10 @@
                 ],
                 "VPCZoneIdentifier": [
                     {
-                        "Ref": "PrivateASubnet"
+                        "Ref": "PrivateSubnetA"
                     },
                     {
-                        "Ref": "PrivateBSubnet"
+                        "Ref": "PrivateSubnetB"
                     }
                 ]
             },
@@ -769,10 +824,10 @@
                 ],
                 "VPCZoneIdentifier": [
                     {
-                        "Ref": "PrivateASubnet"
+                        "Ref": "PrivateSubnetA"
                     },
                     {
-                        "Ref": "PrivateBSubnet"
+                        "Ref": "PrivateSubnetB"
                     }
                 ]
             },
@@ -895,10 +950,10 @@
                 ],
                 "Subnets": [
                     {
-                        "Ref": "PublicASubnet"
+                        "Ref": "PublicSubnetA"
                     },
                     {
-                        "Ref": "PublicBSubnet"
+                        "Ref": "PublicSubnetB"
                     }
                 ]
             },
@@ -975,10 +1030,10 @@
                 ],
                 "Subnets": [
                     {
-                        "Ref": "PublicASubnet"
+                        "Ref": "PublicSubnetA"
                     },
                     {
-                        "Ref": "PublicBSubnet"
+                        "Ref": "PublicSubnetB"
                     }
                 ]
             },
@@ -996,6 +1051,24 @@
             "Type": "AWS::EC2::VPCGatewayAttachment"
         },
         "InternetGateway": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "igw"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
             "Type": "AWS::EC2::InternetGateway"
         },
         "LaunchConfigurationProduction": {
@@ -1038,54 +1111,6 @@
                 "RetentionInDays": 731
             },
             "Type": "AWS::Logs::LogGroup"
-        },
-        "PrivateARouteTableAssociation": {
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateRouteTable"
-                },
-                "SubnetId": {
-                    "Ref": "PrivateASubnet"
-                }
-            },
-            "Type": "AWS::EC2::SubnetRouteTableAssociation"
-        },
-        "PrivateASubnet": {
-            "Properties": {
-                "AvailabilityZone": {
-                    "Ref": "PrimaryAZ"
-                },
-                "CidrBlock": "10.1.2.0/24",
-                "MapPublicIpOnLaunch": "false",
-                "VpcId": {
-                    "Ref": "Vpc"
-                }
-            },
-            "Type": "AWS::EC2::Subnet"
-        },
-        "PrivateBRouteTableAssociation": {
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateRouteTable"
-                },
-                "SubnetId": {
-                    "Ref": "PrivateBSubnet"
-                }
-            },
-            "Type": "AWS::EC2::SubnetRouteTableAssociation"
-        },
-        "PrivateBSubnet": {
-            "Properties": {
-                "AvailabilityZone": {
-                    "Ref": "SecondaryAZ"
-                },
-                "CidrBlock": "10.1.3.0/24",
-                "MapPublicIpOnLaunch": "false",
-                "VpcId": {
-                    "Ref": "Vpc"
-                }
-            },
-            "Type": "AWS::EC2::Subnet"
         },
         "PrivateBucketProduction": {
             "DeletionPolicy": "Retain",
@@ -1259,56 +1284,108 @@
         },
         "PrivateRouteTable": {
             "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "private"
+                                ]
+                            ]
+                        }
+                    }
+                ],
                 "VpcId": {
                     "Ref": "Vpc"
                 }
             },
             "Type": "AWS::EC2::RouteTable"
         },
-        "PublicASubnet": {
+        "PrivateSubnetA": {
             "Properties": {
                 "AvailabilityZone": {
                     "Ref": "PrimaryAZ"
                 },
-                "CidrBlock": "10.1.0.0/24",
-                "MapPublicIpOnLaunch": "true",
+                "CidrBlock": {
+                    "Ref": "PrivateSubnetACidr"
+                },
+                "MapPublicIpOnLaunch": "false",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "private-a"
+                                ]
+                            ]
+                        }
+                    }
+                ],
                 "VpcId": {
                     "Ref": "Vpc"
                 }
             },
             "Type": "AWS::EC2::Subnet"
         },
-        "PublicASubnetRouteTableAssociation": {
+        "PrivateSubnetARouteTableAssociation": {
             "Properties": {
                 "RouteTableId": {
-                    "Ref": "PublicRouteTable"
+                    "Ref": "PrivateRouteTable"
                 },
                 "SubnetId": {
-                    "Ref": "PublicASubnet"
+                    "Ref": "PrivateSubnetA"
                 }
             },
             "Type": "AWS::EC2::SubnetRouteTableAssociation"
         },
-        "PublicBSubnet": {
+        "PrivateSubnetB": {
             "Properties": {
                 "AvailabilityZone": {
                     "Ref": "SecondaryAZ"
                 },
-                "CidrBlock": "10.1.1.0/24",
-                "MapPublicIpOnLaunch": "true",
+                "CidrBlock": {
+                    "Ref": "PrivateSubnetBCidr"
+                },
+                "MapPublicIpOnLaunch": "false",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "private-b"
+                                ]
+                            ]
+                        }
+                    }
+                ],
                 "VpcId": {
                     "Ref": "Vpc"
                 }
             },
             "Type": "AWS::EC2::Subnet"
         },
-        "PublicBSubnetRouteTableAssociation": {
+        "PrivateSubnetBRouteTableAssociation": {
             "Properties": {
                 "RouteTableId": {
-                    "Ref": "PublicRouteTable"
+                    "Ref": "PrivateRouteTable"
                 },
                 "SubnetId": {
-                    "Ref": "PublicBSubnet"
+                    "Ref": "PrivateSubnetB"
                 }
             },
             "Type": "AWS::EC2::SubnetRouteTableAssociation"
@@ -1327,11 +1404,111 @@
         },
         "PublicRouteTable": {
             "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "public"
+                                ]
+                            ]
+                        }
+                    }
+                ],
                 "VpcId": {
                     "Ref": "Vpc"
                 }
             },
             "Type": "AWS::EC2::RouteTable"
+        },
+        "PublicSubnetA": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "PrimaryAZ"
+                },
+                "CidrBlock": {
+                    "Ref": "PublicSubnetACidr"
+                },
+                "MapPublicIpOnLaunch": "true",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "public-a"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PublicSubnetARouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnetA"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PublicSubnetB": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "SecondaryAZ"
+                },
+                "CidrBlock": {
+                    "Ref": "PublicSubnetBCidr"
+                },
+                "MapPublicIpOnLaunch": "true",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "public-b"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PublicSubnetBRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnetB"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
         },
         "RouterEIP": {
             "Properties": {
@@ -1380,7 +1557,9 @@
                         "ToPort": 1194
                     },
                     {
-                        "CidrIp": "10.1.0.0/22",
+                        "CidrIp": {
+                            "Ref": "VpcCidr"
+                        },
                         "FromPort": "-1",
                         "IpProtocol": "-1",
                         "ToPort": "-1"
@@ -1408,9 +1587,27 @@
         },
         "Vpc": {
             "Properties": {
-                "CidrBlock": "10.1.0.0/22",
+                "CidrBlock": {
+                    "Ref": "VpcCidr"
+                },
                 "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true"
+                "EnableDnsSupport": "true",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "vpc"
+                                ]
+                            ]
+                        }
+                    }
+                ]
             },
             "Type": "AWS::EC2::VPC"
         },
@@ -1466,7 +1663,7 @@
                 ],
                 "SourceDestCheck": "false",
                 "SubnetId": {
-                    "Ref": "PublicASubnet"
+                    "Ref": "PublicSubnetA"
                 },
                 "Tags": [
                     {

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -1233,6 +1233,7 @@
             "Type": "AWS::S3::Bucket"
         },
         "ElbProduction": {
+            "DependsOn": "ElbLogsBucketPolicyProduction",
             "Properties": {
                 "AccessLoggingPolicy": {
                     "EmitInterval": 60,
@@ -1320,6 +1321,7 @@
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
         },
         "ElbStaging": {
+            "DependsOn": "ElbLogsBucketPolicyStaging",
             "Properties": {
                 "AccessLoggingPolicy": {
                     "EmitInterval": 60,

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -96,19 +96,6 @@
                 "us-gov-west-1"
             ]
         },
-        "NoAlternateDomains": {
-            "Fn::Equals": [
-                {
-                    "Fn::Join": [
-                        "",
-                        {
-                            "Ref": "DomainNameAlternates"
-                        }
-                    ]
-                },
-                ""
-            ]
-        },
         "TcpHealthCheckProduction": {
             "Fn::Equals": [
                 {
@@ -134,8 +121,8 @@
                         "default": "Global"
                     },
                     "Parameters": [
-                        "DomainName",
-                        "DomainNameAlternates",
+                        "DomainNamesStaging",
+                        "DomainNamesProduction",
                         "PrimaryAZ",
                         "SecondaryAZ",
                         "VpcCidr",
@@ -212,11 +199,11 @@
                 "AutoscalingTargetCPU": {
                     "default": "Autoscaling Target CPU"
                 },
-                "DomainName": {
-                    "default": "Domain Name"
+                "DomainNamesProduction": {
+                    "default": "Domain Names (production)"
                 },
-                "DomainNameAlternates": {
-                    "default": "Alternate Domain Names"
+                "DomainNamesStaging": {
+                    "default": "Domain Names (staging)"
                 },
                 "ElbAccountID": {
                     "default": "Elastic Load Balancing Account ID"
@@ -421,12 +408,12 @@
             "Description": "Target CPU utilization for the autoscaling group (e.g., \"40.0\" for 40%).",
             "Type": "Number"
         },
-        "DomainName": {
-            "Description": "The fully-qualified domain name for the application.",
-            "Type": "String"
+        "DomainNamesProduction": {
+            "Description": "A comma-separated list of FQDNs for production.",
+            "Type": "CommaDelimitedList"
         },
-        "DomainNameAlternates": {
-            "Description": "A comma-separated list of Alternate FQDNs.",
+        "DomainNamesStaging": {
+            "Description": "A comma-separated list of FQDNs for staging.",
             "Type": "CommaDelimitedList"
         },
         "ElbAccountID": {
@@ -541,20 +528,10 @@
                                             [
                                                 "https://",
                                                 {
-                                                    "Ref": "DomainName"
-                                                },
-                                                {
-                                                    "Fn::If": [
-                                                        "NoAlternateDomains",
-                                                        "",
-                                                        ";https://"
-                                                    ]
-                                                },
-                                                {
                                                     "Fn::Join": [
                                                         ";https://",
                                                         {
-                                                            "Ref": "DomainNameAlternates"
+                                                            "Ref": "DomainNamesProduction"
                                                         }
                                                     ]
                                                 }
@@ -614,20 +591,10 @@
                                             [
                                                 "https://",
                                                 {
-                                                    "Ref": "DomainName"
-                                                },
-                                                {
-                                                    "Fn::If": [
-                                                        "NoAlternateDomains",
-                                                        "",
-                                                        ";https://"
-                                                    ]
-                                                },
-                                                {
                                                     "Fn::Join": [
                                                         ";https://",
                                                         {
-                                                            "Ref": "DomainNameAlternates"
+                                                            "Ref": "DomainNamesStaging"
                                                         }
                                                     ]
                                                 }
@@ -1523,20 +1490,10 @@
                                             [
                                                 "https://",
                                                 {
-                                                    "Ref": "DomainName"
-                                                },
-                                                {
-                                                    "Fn::If": [
-                                                        "NoAlternateDomains",
-                                                        "",
-                                                        ";https://"
-                                                    ]
-                                                },
-                                                {
                                                     "Fn::Join": [
                                                         ";https://",
                                                         {
-                                                            "Ref": "DomainNameAlternates"
+                                                            "Ref": "DomainNamesProduction"
                                                         }
                                                     ]
                                                 }
@@ -1602,20 +1559,10 @@
                                             [
                                                 "https://",
                                                 {
-                                                    "Ref": "DomainName"
-                                                },
-                                                {
-                                                    "Fn::If": [
-                                                        "NoAlternateDomains",
-                                                        "",
-                                                        ";https://"
-                                                    ]
-                                                },
-                                                {
                                                     "Fn::Join": [
                                                         ";https://",
                                                         {
-                                                            "Ref": "DomainNameAlternates"
+                                                            "Ref": "DomainNamesStaging"
                                                         }
                                                     ]
                                                 }

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -697,7 +697,7 @@
         "AutoScalingGroupProduction": {
             "Properties": {
                 "HealthCheckGracePeriod": 300,
-                "HealthCheckType": "EC2",
+                "HealthCheckType": "ELB",
                 "LaunchConfigurationName": {
                     "Ref": "LaunchConfigurationProduction"
                 },
@@ -739,13 +739,13 @@
         "AutoScalingGroupStaging": {
             "Properties": {
                 "HealthCheckGracePeriod": 300,
-                "HealthCheckType": "EC2",
+                "HealthCheckType": "ELB",
                 "LaunchConfigurationName": {
                     "Ref": "LaunchConfigurationStaging"
                 },
                 "LoadBalancerNames": [
                     {
-                        "Ref": "LoadBalancerProduction"
+                        "Ref": "LoadBalancerStaging"
                     }
                 ],
                 "MaxSize": "32",

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -726,7 +726,7 @@
                         {
                             "DomainName": {
                                 "Fn::GetAtt": [
-                                    "AssetsBucketProduction",
+                                    "AssetsBucketStaging",
                                     "DomainName"
                                 ]
                             },

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -24,6 +24,18 @@
                 }
             ]
         },
+        "AcmCertConditionTesting": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AcmCertArnTesting"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "AssetsCloudFrontCertArnCondition": {
             "Fn::Not": [
                 {
@@ -111,6 +123,14 @@
                 },
                 ""
             ]
+        },
+        "TcpHealthCheckTesting": {
+            "Fn::Equals": [
+                {
+                    "Ref": "WebWorkerHealthCheck"
+                },
+                ""
+            ]
         }
     },
     "Metadata": {
@@ -121,6 +141,7 @@
                         "default": "Global"
                     },
                     "Parameters": [
+                        "DomainNamesTesting",
                         "DomainNamesStaging",
                         "DomainNamesProduction",
                         "PrimaryAZ",
@@ -139,6 +160,7 @@
                     "Parameters": [
                         "WebWorkerHealthCheck",
                         "ElbAccountID",
+                        "AcmCertArnTesting",
                         "AcmCertArnStaging",
                         "AcmCertArnProduction"
                     ]
@@ -181,6 +203,9 @@
                 "AcmCertArnStaging": {
                     "default": "ACM Certificate ARN (staging)"
                 },
+                "AcmCertArnTesting": {
+                    "default": "ACM Certificate ARN (testing)"
+                },
                 "AssetsCloudFrontCertArn": {
                     "default": "CloudFront SSL Certificate ARN"
                 },
@@ -204,6 +229,9 @@
                 },
                 "DomainNamesStaging": {
                     "default": "Domain Names (staging)"
+                },
+                "DomainNamesTesting": {
+                    "default": "Domain Names (testing)"
                 },
                 "ElbAccountID": {
                     "default": "Elastic Load Balancing Account ID"
@@ -263,6 +291,15 @@
                 ]
             }
         },
+        "AssetsBucketTestingDomainName": {
+            "Description": "Assets bucket domain name (testing)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "AssetsBucketTesting",
+                    "DomainName"
+                ]
+            }
+        },
         "AssetsDistributionProductionDomainName": {
             "Condition": "AssetsUseCloudFrontCondition",
             "Description": "The assets bucket CDN domain name (production)",
@@ -279,6 +316,16 @@
             "Value": {
                 "Fn::GetAtt": [
                     "AssetsDistributionStaging",
+                    "DomainName"
+                ]
+            }
+        },
+        "AssetsDistributionTestingDomainName": {
+            "Condition": "AssetsUseCloudFrontCondition",
+            "Description": "The assets bucket CDN domain name (testing)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "AssetsDistributionTesting",
                     "DomainName"
                 ]
             }
@@ -301,6 +348,15 @@
                 ]
             }
         },
+        "ElbTestingDnsName": {
+            "Description": "Loadbalancer DNS",
+            "Value": {
+                "Fn::GetAtt": [
+                    "ElbTesting",
+                    "DNSName"
+                ]
+            }
+        },
         "PrivateBucketProductionDomainName": {
             "Description": "Private bucket domain name (production)",
             "Value": {
@@ -319,6 +375,15 @@
                 ]
             }
         },
+        "PrivateBucketTestingDomainName": {
+            "Description": "Private bucket domain name (testing)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "PrivateBucketTesting",
+                    "DomainName"
+                ]
+            }
+        },
         "RouterPublicIP": {
             "Description": "Public IP address of router",
             "Value": {
@@ -333,6 +398,11 @@
             "Type": "String"
         },
         "AcmCertArnStaging": {
+            "Default": "",
+            "Description": "ARN of the AWS Certificate Manager certificate (optional). If omitted, TCP connections will be passed directly to the backend instances on port 443.",
+            "Type": "String"
+        },
+        "AcmCertArnTesting": {
             "Default": "",
             "Description": "ARN of the AWS Certificate Manager certificate (optional). If omitted, TCP connections will be passed directly to the backend instances on port 443.",
             "Type": "String"
@@ -378,6 +448,10 @@
         },
         "DomainNamesStaging": {
             "Description": "A comma-separated list of FQDNs for staging.",
+            "Type": "CommaDelimitedList"
+        },
+        "DomainNamesTesting": {
+            "Description": "A comma-separated list of FQDNs for testing.",
             "Type": "CommaDelimitedList"
         },
         "ElbAccountID": {
@@ -576,6 +650,69 @@
             },
             "Type": "AWS::S3::Bucket"
         },
+        "AssetsBucketTesting": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "CorsConfiguration": {
+                    "CorsRules": [
+                        {
+                            "AllowedHeaders": [
+                                "*"
+                            ],
+                            "AllowedMethods": [
+                                "POST",
+                                "PUT",
+                                "HEAD",
+                                "GET"
+                            ],
+                            "AllowedOrigins": {
+                                "Fn::Split": [
+                                    ";",
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "https://",
+                                                {
+                                                    "Fn::Join": [
+                                                        ";https://",
+                                                        {
+                                                            "Ref": "DomainNamesTesting"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
         "AssetsCertificate": {
             "Condition": "AssetsCloudFrontDomainAndUsEast1Condition",
             "Properties": {
@@ -703,6 +840,79 @@
                             "DomainName": {
                                 "Fn::GetAtt": [
                                     "AssetsBucketStaging",
+                                    "DomainName"
+                                ]
+                            },
+                            "Id": "Assets",
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            }
+                        }
+                    ],
+                    "ViewerCertificate": {
+                        "Fn::If": [
+                            "AssetsCloudFrontDomainAndUsEast1Condition",
+                            {
+                                "AcmCertificateArn": {
+                                    "Ref": "AssetsCertificate"
+                                },
+                                "SslSupportMethod": "sni-only"
+                            },
+                            {
+                                "Fn::If": [
+                                    "AssetsCloudFrontCertArnCondition",
+                                    {
+                                        "AcmCertificateArn": {
+                                            "Ref": "AssetsCloudFrontCertArn"
+                                        },
+                                        "SslSupportMethod": "sni-only"
+                                    },
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "Type": "AWS::CloudFront::Distribution"
+        },
+        "AssetsDistributionTesting": {
+            "Condition": "AssetsUseCloudFrontCondition",
+            "Properties": {
+                "DistributionConfig": {
+                    "Aliases": {
+                        "Fn::If": [
+                            "AssetsCloudFrontDomainCondition",
+                            [
+                                {
+                                    "Ref": "AssetsCloudFrontDomain"
+                                }
+                            ],
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    "DefaultCacheBehavior": {
+                        "ForwardedValues": {
+                            "Headers": [
+                                "Origin",
+                                "Access-Control-Request-Headers",
+                                "Access-Control-Request-Method"
+                            ],
+                            "QueryString": "true"
+                        },
+                        "TargetOriginId": "Assets",
+                        "ViewerProtocolPolicy": "allow-all"
+                    },
+                    "Enabled": "true",
+                    "Origins": [
+                        {
+                            "DomainName": {
+                                "Fn::GetAtt": [
+                                    "AssetsBucketTesting",
                                     "DomainName"
                                 ]
                             },
@@ -872,6 +1082,78 @@
             "Properties": {
                 "AutoScalingGroupName": {
                     "Ref": "AutoScalingGroupStaging"
+                },
+                "PolicyType": "TargetTrackingScaling",
+                "TargetTrackingConfiguration": {
+                    "PredefinedMetricSpecification": {
+                        "PredefinedMetricType": "ASGAverageCPUUtilization"
+                    },
+                    "TargetValue": {
+                        "Ref": "AutoscalingTargetCPU"
+                    }
+                }
+            },
+            "Type": "AWS::AutoScaling::ScalingPolicy"
+        },
+        "AutoScalingGroupTesting": {
+            "Properties": {
+                "HealthCheckGracePeriod": 120,
+                "HealthCheckType": "ELB",
+                "LaunchConfigurationName": {
+                    "Ref": "LaunchConfigurationTesting"
+                },
+                "LoadBalancerNames": [
+                    {
+                        "Ref": "ElbTesting"
+                    }
+                ],
+                "MaxSize": "32",
+                "MinSize": "0",
+                "NotificationConfigurations": [
+                    {
+                        "NotificationTypes": [
+                            "autoscaling:EC2_INSTANCE_LAUNCH",
+                            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+                            "autoscaling:EC2_INSTANCE_TERMINATE",
+                            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
+                        ],
+                        "TopicARN": {
+                            "Ref": "AutoscalingNotificationsArn"
+                        }
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "PropagateAtLaunch": true,
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "web_worker"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "VPCZoneIdentifier": [
+                    {
+                        "Ref": "PrivateSubnetA"
+                    },
+                    {
+                        "Ref": "PrivateSubnetB"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::AutoScalingGroup"
+        },
+        "AutoScalingGroupTestingScalingPolicy": {
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "AutoScalingGroupTesting"
                 },
                 "PolicyType": "TargetTrackingScaling",
                 "TargetTrackingConfiguration": {
@@ -1060,6 +1342,77 @@
                         "Ref": "BucketLogsBucket"
                     },
                     "LogFilePrefix": "StagingBackups/"
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "BackupsBucketTesting": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "ExpirationInDays": 14,
+                            "Id": "Keep Hourly for 14 days",
+                            "Prefix": "_hourly",
+                            "Status": "Enabled"
+                        },
+                        {
+                            "Id": "Transition to IA after 30 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 30
+                                }
+                            ]
+                        },
+                        {
+                            "ExpirationInDays": 90,
+                            "Id": "Keep Daily for 90 days",
+                            "Prefix": "__daily",
+                            "Status": "Enabled"
+                        },
+                        {
+                            "ExpirationInDays": 365,
+                            "Id": "Keep Weekly for 365 days",
+                            "Prefix": "___weekly",
+                            "Status": "Enabled"
+                        }
+                    ]
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "TestingBackups/"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
@@ -1401,6 +1754,95 @@
             },
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
         },
+        "ElbTesting": {
+            "DependsOn": "ElbLogsBucketPolicy",
+            "Properties": {
+                "AccessLoggingPolicy": {
+                    "EmitInterval": 60,
+                    "Enabled": true,
+                    "S3BucketName": {
+                        "Ref": "ElbLogsBucket"
+                    },
+                    "S3BucketPrefix": "testing"
+                },
+                "CrossZone": "true",
+                "HealthCheck": {
+                    "HealthyThreshold": "2",
+                    "Interval": "10",
+                    "Target": {
+                        "Fn::If": [
+                            "TcpHealthCheckTesting",
+                            "TCP:80",
+                            {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "HTTPS:443",
+                                        {
+                                            "Ref": "WebWorkerHealthCheck"
+                                        }
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    "Timeout": "9",
+                    "UnhealthyThreshold": "2"
+                },
+                "Instances": [],
+                "Listeners": [
+                    {
+                        "InstancePort": 80,
+                        "InstanceProtocol": "HTTP",
+                        "LoadBalancerPort": 80,
+                        "Protocol": "HTTP"
+                    },
+                    {
+                        "InstancePort": 443,
+                        "InstanceProtocol": {
+                            "Fn::If": [
+                                "AcmCertConditionTesting",
+                                "HTTPS",
+                                "TCP"
+                            ]
+                        },
+                        "LoadBalancerPort": 443,
+                        "Protocol": {
+                            "Fn::If": [
+                                "AcmCertConditionTesting",
+                                "HTTPS",
+                                "TCP"
+                            ]
+                        },
+                        "SSLCertificateId": {
+                            "Fn::If": [
+                                "AcmCertConditionTesting",
+                                {
+                                    "Ref": "AcmCertArnTesting"
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "SecurityGroups": [
+                    {
+                        "Ref": "AwsElbSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PublicSubnetA"
+                    },
+                    {
+                        "Ref": "PublicSubnetB"
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
         "GatewayAttachement": {
             "Properties": {
                 "InternetGatewayId": {
@@ -1451,6 +1893,23 @@
             "Type": "AWS::AutoScaling::LaunchConfiguration"
         },
         "LaunchConfigurationStaging": {
+            "Properties": {
+                "ImageId": {
+                    "Ref": "RouterAMI"
+                },
+                "InstanceType": "t2.nano",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "WebServerSecurityGroup"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "LaunchConfigurationTesting": {
             "Properties": {
                 "ImageId": {
                     "Ref": "RouterAMI"
@@ -1639,6 +2098,95 @@
                         "Ref": "BucketLogsBucket"
                     },
                     "LogFilePrefix": "StagingPrivate/"
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "PrivateBucketTesting": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "CorsConfiguration": {
+                    "CorsRules": [
+                        {
+                            "AllowedHeaders": [
+                                "*"
+                            ],
+                            "AllowedMethods": [
+                                "POST",
+                                "PUT",
+                                "HEAD",
+                                "GET"
+                            ],
+                            "AllowedOrigins": {
+                                "Fn::Split": [
+                                    ";",
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "https://",
+                                                {
+                                                    "Fn::Join": [
+                                                        ";https://",
+                                                        {
+                                                            "Ref": "DomainNamesTesting"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "Id": "Transition to IA after 365 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 365
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "TestingPrivate/"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -1447,6 +1447,7 @@
                         }
                     }
                 ],
+                "DisableApiTermination": "true",
                 "ImageId": {
                     "Ref": "RouterAMI"
                 },

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -952,6 +952,38 @@
                         ]
                     }
                 },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "ExpirationInDays": 14,
+                            "Id": "Keep Hourly for 14 days",
+                            "Prefix": "_hourly",
+                            "Status": "Enabled"
+                        },
+                        {
+                            "Id": "Transition to IA after 30 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 30
+                                }
+                            ]
+                        },
+                        {
+                            "ExpirationInDays": 90,
+                            "Id": "Keep Daily for 90 days",
+                            "Prefix": "__daily",
+                            "Status": "Enabled"
+                        },
+                        {
+                            "ExpirationInDays": 365,
+                            "Id": "Keep Weekly for 365 days",
+                            "Prefix": "___weekly",
+                            "Status": "Enabled"
+                        }
+                    ]
+                },
                 "LoggingConfiguration": {
                     "DestinationBucketName": {
                         "Ref": "BucketLogsBucket"
@@ -990,6 +1022,38 @@
                             ]
                         ]
                     }
+                },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "ExpirationInDays": 14,
+                            "Id": "Keep Hourly for 14 days",
+                            "Prefix": "_hourly",
+                            "Status": "Enabled"
+                        },
+                        {
+                            "Id": "Transition to IA after 30 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 30
+                                }
+                            ]
+                        },
+                        {
+                            "ExpirationInDays": 90,
+                            "Id": "Keep Daily for 90 days",
+                            "Prefix": "__daily",
+                            "Status": "Enabled"
+                        },
+                        {
+                            "ExpirationInDays": 365,
+                            "Id": "Keep Weekly for 365 days",
+                            "Prefix": "___weekly",
+                            "Status": "Enabled"
+                        }
+                    ]
                 },
                 "LoggingConfiguration": {
                     "DestinationBucketName": {
@@ -1030,6 +1094,20 @@
                         ]
                     }
                 },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "Id": "Transition to IA after 30 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 30
+                                }
+                            ]
+                        }
+                    ]
+                },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
                     "BlockPublicPolicy": "true",
@@ -1062,6 +1140,20 @@
                             ]
                         ]
                     }
+                },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "Id": "Transition to IA after 30 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 30
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "LoggingConfiguration": {
                     "DestinationBucketName": {
@@ -1439,6 +1531,20 @@
                         }
                     ]
                 },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "Id": "Transition to IA after 365 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 365
+                                }
+                            ]
+                        }
+                    ]
+                },
                 "LoggingConfiguration": {
                     "DestinationBucketName": {
                         "Ref": "BucketLogsBucket"
@@ -1511,6 +1617,20 @@
                                     }
                                 ]
                             }
+                        }
+                    ]
+                },
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "Id": "Transition to IA after 365 days",
+                            "Status": "Enabled",
+                            "Transitions": [
+                                {
+                                    "StorageClass": "STANDARD_IA",
+                                    "TransitionInDays": 365
+                                }
+                            ]
                         }
                     ]
                 },

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -1954,6 +1954,22 @@
             },
             "Type": "AWS::EC2::SecurityGroupIngress"
         },
+        "VPCS3Endpoint": {
+            "Properties": {
+                "RouteTableIds": [
+                    {
+                        "Ref": "PrivateRouteTable"
+                    }
+                ],
+                "ServiceName": {
+                    "Fn::Sub": "com.amazonaws.${AWS::Region}.s3"
+                },
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::VPCEndpoint"
+        },
         "Vpc": {
             "Properties": {
                 "CidrBlock": {

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -1,0 +1,1490 @@
+{
+    "Conditions": {
+        "AcmCertConditionProduction": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AcmCertArnProduction"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "AcmCertConditionStaging": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AcmCertArnStaging"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "AssetsCloudFrontCertArnCondition": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AssetsCloudFrontCertArn"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "AssetsCloudFrontDomainAndUsEast1Condition": {
+            "Fn::And": [
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "AssetsCloudFrontDomain"
+                                },
+                                ""
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "us-east-1"
+                    ]
+                }
+            ]
+        },
+        "AssetsCloudFrontDomainCondition": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AssetsCloudFrontDomain"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "AssetsUseCloudFrontCondition": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AssetsUseCloudFront"
+                },
+                "true"
+            ]
+        },
+        "AssetsUseS3EncryptionCondition": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AssetsUseAES256Encryption"
+                },
+                "true"
+            ]
+        },
+        "InGovCloudRegion": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AWS::Region"
+                },
+                "us-gov-west-1"
+            ]
+        },
+        "NoAlternateDomains": {
+            "Fn::Equals": [
+                {
+                    "Fn::Join": [
+                        "",
+                        {
+                            "Ref": "DomainNameAlternates"
+                        }
+                    ]
+                },
+                ""
+            ]
+        },
+        "TcpHealthCheckProduction": {
+            "Fn::Equals": [
+                {
+                    "Ref": "WebWorkerHealthCheck"
+                },
+                ""
+            ]
+        },
+        "TcpHealthCheckStaging": {
+            "Fn::Equals": [
+                {
+                    "Ref": "WebWorkerHealthCheck"
+                },
+                ""
+            ]
+        }
+    },
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Global"
+                    },
+                    "Parameters": [
+                        "DomainName",
+                        "DomainNameAlternates",
+                        "PrimaryAZ",
+                        "SecondaryAZ"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Load Balancer"
+                    },
+                    "Parameters": [
+                        "WebWorkerHealthCheck",
+                        "AcmCertArnStaging",
+                        "AcmCertArnProduction"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Static Media"
+                    },
+                    "Parameters": [
+                        "AssetsUseAES256Encryption",
+                        "AssetsUseCloudFront",
+                        "AssetsCloudFrontDomain",
+                        "AssetsCloudFrontCertArn"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Networking"
+                    },
+                    "Parameters": [
+                        "LocalCidr"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "EC2"
+                    },
+                    "Parameters": [
+                        "RouterAMI",
+                        "KeyName"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "AcmCertArnProduction": {
+                    "default": "ACM Certificate ARN (production)"
+                },
+                "AcmCertArnStaging": {
+                    "default": "ACM Certificate ARN (staging)"
+                },
+                "AssetsCloudFrontCertArn": {
+                    "default": "CloudFront SSL Certificate ARN"
+                },
+                "AssetsCloudFrontDomain": {
+                    "default": "CloudFront Custom Domain"
+                },
+                "AssetsUseAES256Encryption": {
+                    "default": "Enable AES256 Encryption"
+                },
+                "AssetsUseCloudFront": {
+                    "default": "Enable CloudFront"
+                },
+                "DomainName": {
+                    "default": "Domain Name"
+                },
+                "DomainNameAlternates": {
+                    "default": "Alternate Domain Names"
+                },
+                "KeyName": {
+                    "default": "SSH Key Name"
+                },
+                "LocalCidr": {
+                    "default": "Local CIDR"
+                },
+                "PrimaryAZ": {
+                    "default": "Primary Availability Zone"
+                },
+                "RouterAMI": {
+                    "default": "Router AMI"
+                },
+                "SecondaryAZ": {
+                    "default": "Secondary Availability Zone"
+                },
+                "WebWorkerHealthCheck": {
+                    "default": "Health Check URL"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "AssetsBucketProductionDomainName": {
+            "Description": "Assets bucket domain name (production)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "AssetsBucketProduction",
+                    "DomainName"
+                ]
+            }
+        },
+        "AssetsBucketStagingDomainName": {
+            "Description": "Assets bucket domain name (staging)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "AssetsBucketStaging",
+                    "DomainName"
+                ]
+            }
+        },
+        "AssetsDistributionProductionDomainName": {
+            "Condition": "AssetsUseCloudFrontCondition",
+            "Description": "The assets bucket CDN domain name (production)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "AssetsDistributionProduction",
+                    "DomainName"
+                ]
+            }
+        },
+        "AssetsDistributionStagingDomainName": {
+            "Condition": "AssetsUseCloudFrontCondition",
+            "Description": "The assets bucket CDN domain name (staging)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "AssetsDistributionStaging",
+                    "DomainName"
+                ]
+            }
+        },
+        "LoadBalancerProductionDNSName": {
+            "Description": "Loadbalancer DNS",
+            "Value": {
+                "Fn::GetAtt": [
+                    "LoadBalancerProduction",
+                    "DNSName"
+                ]
+            }
+        },
+        "LoadBalancerStagingDNSName": {
+            "Description": "Loadbalancer DNS",
+            "Value": {
+                "Fn::GetAtt": [
+                    "LoadBalancerStaging",
+                    "DNSName"
+                ]
+            }
+        },
+        "PrivateBucketProductionDomainName": {
+            "Description": "Private bucket domain name (production)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "PrivateBucketProduction",
+                    "DomainName"
+                ]
+            }
+        },
+        "PrivateBucketStagingDomainName": {
+            "Description": "Private bucket domain name (staging)",
+            "Value": {
+                "Fn::GetAtt": [
+                    "PrivateBucketStaging",
+                    "DomainName"
+                ]
+            }
+        },
+        "RouterPublicIP": {
+            "Description": "Public IP address of router",
+            "Value": {
+                "Ref": "RouterEIP"
+            }
+        }
+    },
+    "Parameters": {
+        "AcmCertArnProduction": {
+            "Default": "",
+            "Description": "ARN of the AWS Certificate Manager certificate (optional). If omitted, TCP connections will be passed directly to the backend instances on port 443.",
+            "Type": "String"
+        },
+        "AcmCertArnStaging": {
+            "Default": "",
+            "Description": "ARN of the AWS Certificate Manager certificate (optional). If omitted, TCP connections will be passed directly to the backend instances on port 443.",
+            "Type": "String"
+        },
+        "AssetsCloudFrontCertArn": {
+            "Description": "If (1) you specified a custom static media domain, (2) your stack is NOT in the us-east-1 region, and (3) you wish to serve static media over HTTPS, you must manually create an ACM certificate in the us-east-1 region and provide its ARN here.",
+            "Type": "String"
+        },
+        "AssetsCloudFrontDomain": {
+            "Default": "",
+            "Description": "A custom domain name (CNAME) for your CloudFront distribution, e.g., \"static.example.com\".",
+            "Type": "String"
+        },
+        "AssetsUseAES256Encryption": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "true",
+            "Description": "Whether or not to use server side encryption for S3 buckets. When true, AES256 encryption is enabled for all asset buckets.",
+            "Type": "String"
+        },
+        "AssetsUseCloudFront": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "true",
+            "Description": "Whether or not to create a CloudFront distribution tied to the S3 assets bucket.",
+            "Type": "String"
+        },
+        "DomainName": {
+            "Description": "The fully-qualified domain name for the application.",
+            "Type": "String"
+        },
+        "DomainNameAlternates": {
+            "Description": "A comma-separated list of Alternate FQDNs.",
+            "Type": "CommaDelimitedList"
+        },
+        "KeyName": {
+            "ConstraintDescription": "must be the name of an existing EC2 KeyPair.",
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access to the AWS EC2 instances",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "LocalCidr": {
+            "Default": "0.0.0.0/0",
+            "Description": "CIDR block from which to allow restricted access. Set this to \"<your IP>/32\".",
+            "Type": "String"
+        },
+        "PrimaryAZ": {
+            "Description": "The primary availability zone for creating resources.",
+            "Type": "AWS::EC2::AvailabilityZone::Name"
+        },
+        "RouterAMI": {
+            "Default": "ami-089c333c4d9b09ffc",
+            "Description": "pfSense AMI from the AWS marketplace in the same region as this stack",
+            "Type": "String"
+        },
+        "SecondaryAZ": {
+            "Description": "The secondary availability zone for creating resources. Must differ from primary zone.",
+            "Type": "AWS::EC2::AvailabilityZone::Name"
+        },
+        "WebWorkerHealthCheck": {
+            "Default": "",
+            "Description": "Web worker health check URL path, e.g., \"/health-check\"; will default to TCP-only health check if left blank",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "AssetsBucketProduction": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "PublicRead",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "CorsConfiguration": {
+                    "CorsRules": [
+                        {
+                            "AllowedHeaders": [
+                                "*"
+                            ],
+                            "AllowedMethods": [
+                                "POST",
+                                "PUT",
+                                "HEAD",
+                                "GET"
+                            ],
+                            "AllowedOrigins": {
+                                "Fn::Split": [
+                                    ";",
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "https://",
+                                                {
+                                                    "Ref": "DomainName"
+                                                },
+                                                {
+                                                    "Fn::If": [
+                                                        "NoAlternateDomains",
+                                                        "",
+                                                        ";https://"
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::Join": [
+                                                        ";https://",
+                                                        {
+                                                            "Ref": "DomainNameAlternates"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "AssetsBucketStaging": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "PublicRead",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "CorsConfiguration": {
+                    "CorsRules": [
+                        {
+                            "AllowedHeaders": [
+                                "*"
+                            ],
+                            "AllowedMethods": [
+                                "POST",
+                                "PUT",
+                                "HEAD",
+                                "GET"
+                            ],
+                            "AllowedOrigins": {
+                                "Fn::Split": [
+                                    ";",
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "https://",
+                                                {
+                                                    "Ref": "DomainName"
+                                                },
+                                                {
+                                                    "Fn::If": [
+                                                        "NoAlternateDomains",
+                                                        "",
+                                                        ";https://"
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::Join": [
+                                                        ";https://",
+                                                        {
+                                                            "Ref": "DomainNameAlternates"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "AssetsCertificate": {
+            "Condition": "AssetsCloudFrontDomainAndUsEast1Condition",
+            "Properties": {
+                "DomainName": {
+                    "Ref": "AssetsCloudFrontDomain"
+                },
+                "DomainValidationOptions": [
+                    {
+                        "DomainName": {
+                            "Ref": "AssetsCloudFrontDomain"
+                        },
+                        "ValidationDomain": {
+                            "Ref": "AssetsCloudFrontDomain"
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::CertificateManager::Certificate"
+        },
+        "AssetsDistributionProduction": {
+            "Condition": "AssetsUseCloudFrontCondition",
+            "Properties": {
+                "DistributionConfig": {
+                    "Aliases": {
+                        "Fn::If": [
+                            "AssetsCloudFrontDomainCondition",
+                            [
+                                {
+                                    "Ref": "AssetsCloudFrontDomain"
+                                }
+                            ],
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    "DefaultCacheBehavior": {
+                        "ForwardedValues": {
+                            "Headers": [
+                                "Origin",
+                                "Access-Control-Request-Headers",
+                                "Access-Control-Request-Method"
+                            ],
+                            "QueryString": "true"
+                        },
+                        "TargetOriginId": "Assets",
+                        "ViewerProtocolPolicy": "allow-all"
+                    },
+                    "Enabled": "true",
+                    "Origins": [
+                        {
+                            "DomainName": {
+                                "Fn::GetAtt": [
+                                    "AssetsBucketProduction",
+                                    "DomainName"
+                                ]
+                            },
+                            "Id": "Assets",
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            }
+                        }
+                    ],
+                    "ViewerCertificate": {
+                        "Fn::If": [
+                            "AssetsCloudFrontDomainAndUsEast1Condition",
+                            {
+                                "AcmCertificateArn": {
+                                    "Ref": "AssetsCertificate"
+                                },
+                                "SslSupportMethod": "sni-only"
+                            },
+                            {
+                                "Fn::If": [
+                                    "AssetsCloudFrontCertArnCondition",
+                                    {
+                                        "AcmCertificateArn": {
+                                            "Ref": "AssetsCloudFrontCertArn"
+                                        },
+                                        "SslSupportMethod": "sni-only"
+                                    },
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "Type": "AWS::CloudFront::Distribution"
+        },
+        "AssetsDistributionStaging": {
+            "Condition": "AssetsUseCloudFrontCondition",
+            "Properties": {
+                "DistributionConfig": {
+                    "Aliases": {
+                        "Fn::If": [
+                            "AssetsCloudFrontDomainCondition",
+                            [
+                                {
+                                    "Ref": "AssetsCloudFrontDomain"
+                                }
+                            ],
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    "DefaultCacheBehavior": {
+                        "ForwardedValues": {
+                            "Headers": [
+                                "Origin",
+                                "Access-Control-Request-Headers",
+                                "Access-Control-Request-Method"
+                            ],
+                            "QueryString": "true"
+                        },
+                        "TargetOriginId": "Assets",
+                        "ViewerProtocolPolicy": "allow-all"
+                    },
+                    "Enabled": "true",
+                    "Origins": [
+                        {
+                            "DomainName": {
+                                "Fn::GetAtt": [
+                                    "AssetsBucketProduction",
+                                    "DomainName"
+                                ]
+                            },
+                            "Id": "Assets",
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            }
+                        }
+                    ],
+                    "ViewerCertificate": {
+                        "Fn::If": [
+                            "AssetsCloudFrontDomainAndUsEast1Condition",
+                            {
+                                "AcmCertificateArn": {
+                                    "Ref": "AssetsCertificate"
+                                },
+                                "SslSupportMethod": "sni-only"
+                            },
+                            {
+                                "Fn::If": [
+                                    "AssetsCloudFrontCertArnCondition",
+                                    {
+                                        "AcmCertificateArn": {
+                                            "Ref": "AssetsCloudFrontCertArn"
+                                        },
+                                        "SslSupportMethod": "sni-only"
+                                    },
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "Type": "AWS::CloudFront::Distribution"
+        },
+        "AutoScalingGroupProduction": {
+            "Properties": {
+                "DesiredCapacity": "0",
+                "HealthCheckGracePeriod": 300,
+                "HealthCheckType": "EC2",
+                "LaunchConfigurationName": {
+                    "Ref": "LaunchConfigurationProduction"
+                },
+                "LoadBalancerNames": [
+                    {
+                        "Ref": "LoadBalancerProduction"
+                    }
+                ],
+                "MaxSize": "32",
+                "MinSize": "0",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "PropagateAtLaunch": true,
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "web_worker"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "VPCZoneIdentifier": [
+                    {
+                        "Ref": "PrivateASubnet"
+                    },
+                    {
+                        "Ref": "PrivateBSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::AutoScalingGroup"
+        },
+        "AutoScalingGroupStaging": {
+            "Properties": {
+                "DesiredCapacity": "0",
+                "HealthCheckGracePeriod": 300,
+                "HealthCheckType": "EC2",
+                "LaunchConfigurationName": {
+                    "Ref": "LaunchConfigurationStaging"
+                },
+                "LoadBalancerNames": [
+                    {
+                        "Ref": "LoadBalancerProduction"
+                    }
+                ],
+                "MaxSize": "32",
+                "MinSize": "0",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "PropagateAtLaunch": true,
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "web_worker"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "VPCZoneIdentifier": [
+                    {
+                        "Ref": "PrivateASubnet"
+                    },
+                    {
+                        "Ref": "PrivateBSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::AutoScalingGroup"
+        },
+        "AwsElbSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "AWS elastic load balancer security group.",
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "ToPort": "80"
+                    },
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "443",
+                        "IpProtocol": "tcp",
+                        "ToPort": "443"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "BackendSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow full access between the Backend Instances",
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "BackendSecurityGroupIngressRule": {
+            "Properties": {
+                "FromPort": "-1",
+                "GroupId": {
+                    "Ref": "BackendSecurityGroup"
+                },
+                "IpProtocol": "-1",
+                "SourceSecurityGroupId": {
+                    "Ref": "BackendSecurityGroup"
+                },
+                "ToPort": "-1"
+            },
+            "Type": "AWS::EC2::SecurityGroupIngress"
+        },
+        "GatewayAttachement": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "LaunchConfigurationProduction": {
+            "Properties": {
+                "ImageId": {
+                    "Ref": "RouterAMI"
+                },
+                "InstanceType": "t2.nano",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "WebServerSecurityGroup"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "LaunchConfigurationStaging": {
+            "Properties": {
+                "ImageId": {
+                    "Ref": "RouterAMI"
+                },
+                "InstanceType": "t2.nano",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "WebServerSecurityGroup"
+                    }
+                ]
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "LoadBalancerProduction": {
+            "Properties": {
+                "CrossZone": "true",
+                "HealthCheck": {
+                    "HealthyThreshold": "2",
+                    "Interval": "10",
+                    "Target": {
+                        "Fn::If": [
+                            "TcpHealthCheckProduction",
+                            "TCP:80",
+                            {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "HTTPS:80",
+                                        {
+                                            "Ref": "WebWorkerHealthCheck"
+                                        }
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    "Timeout": "9",
+                    "UnhealthyThreshold": "2"
+                },
+                "Instances": [],
+                "Listeners": [
+                    {
+                        "InstancePort": 80,
+                        "InstanceProtocol": "HTTP",
+                        "LoadBalancerPort": 80,
+                        "Protocol": "HTTP"
+                    },
+                    {
+                        "InstancePort": 80,
+                        "InstanceProtocol": {
+                            "Fn::If": [
+                                "AcmCertConditionProduction",
+                                "HTTP",
+                                "TCP"
+                            ]
+                        },
+                        "LoadBalancerPort": 443,
+                        "Protocol": {
+                            "Fn::If": [
+                                "AcmCertConditionProduction",
+                                "HTTPS",
+                                "TCP"
+                            ]
+                        },
+                        "SSLCertificateId": {
+                            "Fn::If": [
+                                "AcmCertConditionProduction",
+                                {
+                                    "Ref": "AcmCertArnProduction"
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "SecurityGroups": [
+                    {
+                        "Ref": "AwsElbSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PublicASubnet"
+                    },
+                    {
+                        "Ref": "PublicBSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "LoadBalancerStaging": {
+            "Properties": {
+                "CrossZone": "true",
+                "HealthCheck": {
+                    "HealthyThreshold": "2",
+                    "Interval": "10",
+                    "Target": {
+                        "Fn::If": [
+                            "TcpHealthCheckStaging",
+                            "TCP:80",
+                            {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "HTTPS:80",
+                                        {
+                                            "Ref": "WebWorkerHealthCheck"
+                                        }
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    "Timeout": "9",
+                    "UnhealthyThreshold": "2"
+                },
+                "Instances": [],
+                "Listeners": [
+                    {
+                        "InstancePort": 80,
+                        "InstanceProtocol": "HTTP",
+                        "LoadBalancerPort": 80,
+                        "Protocol": "HTTP"
+                    },
+                    {
+                        "InstancePort": 80,
+                        "InstanceProtocol": {
+                            "Fn::If": [
+                                "AcmCertConditionStaging",
+                                "HTTP",
+                                "TCP"
+                            ]
+                        },
+                        "LoadBalancerPort": 443,
+                        "Protocol": {
+                            "Fn::If": [
+                                "AcmCertConditionStaging",
+                                "HTTPS",
+                                "TCP"
+                            ]
+                        },
+                        "SSLCertificateId": {
+                            "Fn::If": [
+                                "AcmCertConditionStaging",
+                                {
+                                    "Ref": "AcmCertArnStaging"
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "SecurityGroups": [
+                    {
+                        "Ref": "AwsElbSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PublicASubnet"
+                    },
+                    {
+                        "Ref": "PublicBSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "LogGroup": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "RetentionInDays": 731
+            },
+            "Type": "AWS::Logs::LogGroup"
+        },
+        "PrivateARouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PrivateASubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PrivateASubnet": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "PrimaryAZ"
+                },
+                "CidrBlock": "10.1.2.0/24",
+                "MapPublicIpOnLaunch": "false",
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PrivateBRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PrivateBSubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PrivateBSubnet": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "SecondaryAZ"
+                },
+                "CidrBlock": "10.1.3.0/24",
+                "MapPublicIpOnLaunch": "false",
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PrivateBucketProduction": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "CorsConfiguration": {
+                    "CorsRules": [
+                        {
+                            "AllowedHeaders": [
+                                "*"
+                            ],
+                            "AllowedMethods": [
+                                "POST",
+                                "PUT",
+                                "HEAD",
+                                "GET"
+                            ],
+                            "AllowedOrigins": {
+                                "Fn::Split": [
+                                    ";",
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "https://",
+                                                {
+                                                    "Ref": "DomainName"
+                                                },
+                                                {
+                                                    "Fn::If": [
+                                                        "NoAlternateDomains",
+                                                        "",
+                                                        ";https://"
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::Join": [
+                                                        ";https://",
+                                                        {
+                                                            "Ref": "DomainNameAlternates"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "IgnorePublicAcls": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "PrivateBucketStaging": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "CorsConfiguration": {
+                    "CorsRules": [
+                        {
+                            "AllowedHeaders": [
+                                "*"
+                            ],
+                            "AllowedMethods": [
+                                "POST",
+                                "PUT",
+                                "HEAD",
+                                "GET"
+                            ],
+                            "AllowedOrigins": {
+                                "Fn::Split": [
+                                    ";",
+                                    {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "https://",
+                                                {
+                                                    "Ref": "DomainName"
+                                                },
+                                                {
+                                                    "Fn::If": [
+                                                        "NoAlternateDomains",
+                                                        "",
+                                                        ";https://"
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::Join": [
+                                                        ";https://",
+                                                        {
+                                                            "Ref": "DomainNameAlternates"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "IgnorePublicAcls": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "PrivateNatRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "InstanceId": {
+                    "Ref": "router"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "PrivateRouteTable": {
+            "Properties": {
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "PublicASubnet": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "PrimaryAZ"
+                },
+                "CidrBlock": "10.1.0.0/24",
+                "MapPublicIpOnLaunch": "true",
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PublicASubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PublicASubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PublicBSubnet": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "SecondaryAZ"
+                },
+                "CidrBlock": "10.1.1.0/24",
+                "MapPublicIpOnLaunch": "true",
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PublicBSubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PublicBSubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PublicRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "PublicRouteTable": {
+            "Properties": {
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "RouterEIP": {
+            "Properties": {
+                "Domain": "vpc"
+            },
+            "Type": "AWS::EC2::EIP"
+        },
+        "RouterEipAssociation": {
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
+                        "RouterEIP",
+                        "AllocationId"
+                    ]
+                },
+                "InstanceId": {
+                    "Ref": "router"
+                }
+            },
+            "Type": "AWS::EC2::EIPAssociation"
+        },
+        "RouterSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allows SSH and HTTPS access from LocalCidr, and OpenVPN from anywhere.",
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": {
+                            "Ref": "LocalCidr"
+                        },
+                        "FromPort": 22,
+                        "IpProtocol": "tcp",
+                        "ToPort": 22
+                    },
+                    {
+                        "CidrIp": {
+                            "Ref": "LocalCidr"
+                        },
+                        "FromPort": 443,
+                        "IpProtocol": "tcp",
+                        "ToPort": 443
+                    },
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": 1194,
+                        "IpProtocol": "udp",
+                        "ToPort": 1194
+                    },
+                    {
+                        "CidrIp": "10.1.0.0/22",
+                        "FromPort": "-1",
+                        "IpProtocol": "-1",
+                        "ToPort": "-1"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "RouterToBackendSecurityGroupIngressRule": {
+            "Properties": {
+                "FromPort": "-1",
+                "GroupId": {
+                    "Ref": "BackendSecurityGroup"
+                },
+                "IpProtocol": "-1",
+                "SourceSecurityGroupId": {
+                    "Ref": "RouterSecurityGroup"
+                },
+                "ToPort": "-1"
+            },
+            "Type": "AWS::EC2::SecurityGroupIngress"
+        },
+        "Vpc": {
+            "Properties": {
+                "CidrBlock": "10.1.0.0/22",
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true"
+            },
+            "Type": "AWS::EC2::VPC"
+        },
+        "WebServerSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Backend web server security group.",
+                "SecurityGroupIngress": [
+                    {
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "AwsElbSecurityGroup"
+                        },
+                        "ToPort": "80"
+                    },
+                    {
+                        "FromPort": "443",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "AwsElbSecurityGroup"
+                        },
+                        "ToPort": "443"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "router": {
+            "Properties": {
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "VolumeSize": 8
+                        }
+                    }
+                ],
+                "ImageId": {
+                    "Ref": "RouterAMI"
+                },
+                "InstanceType": "t2.nano",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroupIds": [
+                    {
+                        "Ref": "RouterSecurityGroup"
+                    }
+                ],
+                "SourceDestCheck": "false",
+                "SubnetId": {
+                    "Ref": "PublicASubnet"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": ""
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "-",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    },
+                                    "router"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::EC2::Instance"
+        }
+    }
+}

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -886,7 +886,7 @@
                                 "Fn::Join": [
                                     "",
                                     [
-                                        "HTTPS:80",
+                                        "HTTPS:443",
                                         {
                                             "Ref": "WebWorkerHealthCheck"
                                         }
@@ -966,7 +966,7 @@
                                 "Fn::Join": [
                                     "",
                                     [
-                                        "HTTPS:80",
+                                        "HTTPS:443",
                                         {
                                             "Ref": "WebWorkerHealthCheck"
                                         }

--- a/vpc-template/cloudformation-vpc-template.json
+++ b/vpc-template/cloudformation-vpc-template.json
@@ -956,7 +956,7 @@
                     "DestinationBucketName": {
                         "Ref": "BucketLogsBucket"
                     },
-                    "LogFilePrefix": "ProductionBackups"
+                    "LogFilePrefix": "ProductionBackups/"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
@@ -995,7 +995,7 @@
                     "DestinationBucketName": {
                         "Ref": "BucketLogsBucket"
                     },
-                    "LogFilePrefix": "StagingBackups"
+                    "LogFilePrefix": "StagingBackups/"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
@@ -1042,10 +1042,49 @@
             },
             "Type": "AWS::S3::Bucket"
         },
-        "ElbLogsBucketPolicyProduction": {
+        "ElbLogsBucket": {
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Fn::If": [
+                            "AssetsUseS3EncryptionCondition",
+                            [
+                                {
+                                    "ServerSideEncryptionByDefault": {
+                                        "SSEAlgorithm": "AES256"
+                                    }
+                                }
+                            ],
+                            [
+                                {}
+                            ]
+                        ]
+                    }
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "BucketLogsBucket"
+                    },
+                    "LogFilePrefix": "ElbLogs/"
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": "true",
+                    "BlockPublicPolicy": "true",
+                    "IgnorePublicAcls": "true",
+                    "RestrictPublicBuckets": "true"
+                },
+                "VersioningConfiguration": {
+                    "Status": "Enabled"
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "ElbLogsBucketPolicy": {
             "Properties": {
                 "Bucket": {
-                    "Ref": "ElbLogsBucketProduction"
+                    "Ref": "ElbLogsBucket"
                 },
                 "PolicyDocument": {
                     "Statement": [
@@ -1079,7 +1118,7 @@
                                         },
                                         ":s3:::",
                                         {
-                                            "Ref": "ElbLogsBucketProduction"
+                                            "Ref": "ElbLogsBucket"
                                         },
                                         "/*"
                                     ]
@@ -1091,144 +1130,17 @@
                 }
             },
             "Type": "AWS::S3::BucketPolicy"
-        },
-        "ElbLogsBucketPolicyStaging": {
-            "Properties": {
-                "Bucket": {
-                    "Ref": "ElbLogsBucketStaging"
-                },
-                "PolicyDocument": {
-                    "Statement": [
-                        {
-                            "Action": "s3:PutObject",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "AWS": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "arn:aws:iam::",
-                                            {
-                                                "Ref": "ElbAccountID"
-                                            },
-                                            ":root"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "Resource": {
-                                "Fn::Join": [
-                                    "",
-                                    [
-                                        {
-                                            "Fn::If": [
-                                                "InGovCloudRegion",
-                                                "arn:aws-us-gov",
-                                                "arn:aws"
-                                            ]
-                                        },
-                                        ":s3:::",
-                                        {
-                                            "Ref": "ElbLogsBucketStaging"
-                                        },
-                                        "/*"
-                                    ]
-                                ]
-                            }
-                        }
-                    ],
-                    "Version": "2012-10-17"
-                }
-            },
-            "Type": "AWS::S3::BucketPolicy"
-        },
-        "ElbLogsBucketProduction": {
-            "DeletionPolicy": "Retain",
-            "Properties": {
-                "AccessControl": "Private",
-                "BucketEncryption": {
-                    "ServerSideEncryptionConfiguration": {
-                        "Fn::If": [
-                            "AssetsUseS3EncryptionCondition",
-                            [
-                                {
-                                    "ServerSideEncryptionByDefault": {
-                                        "SSEAlgorithm": "AES256"
-                                    }
-                                }
-                            ],
-                            [
-                                {}
-                            ]
-                        ]
-                    }
-                },
-                "LoggingConfiguration": {
-                    "DestinationBucketName": {
-                        "Ref": "BucketLogsBucket"
-                    },
-                    "LogFilePrefix": "ProductionElbLogs"
-                },
-                "PublicAccessBlockConfiguration": {
-                    "BlockPublicAcls": "true",
-                    "BlockPublicPolicy": "true",
-                    "IgnorePublicAcls": "true",
-                    "RestrictPublicBuckets": "true"
-                },
-                "VersioningConfiguration": {
-                    "Status": "Enabled"
-                }
-            },
-            "Type": "AWS::S3::Bucket"
-        },
-        "ElbLogsBucketStaging": {
-            "DeletionPolicy": "Retain",
-            "Properties": {
-                "AccessControl": "Private",
-                "BucketEncryption": {
-                    "ServerSideEncryptionConfiguration": {
-                        "Fn::If": [
-                            "AssetsUseS3EncryptionCondition",
-                            [
-                                {
-                                    "ServerSideEncryptionByDefault": {
-                                        "SSEAlgorithm": "AES256"
-                                    }
-                                }
-                            ],
-                            [
-                                {}
-                            ]
-                        ]
-                    }
-                },
-                "LoggingConfiguration": {
-                    "DestinationBucketName": {
-                        "Ref": "BucketLogsBucket"
-                    },
-                    "LogFilePrefix": "StagingElbLogs"
-                },
-                "PublicAccessBlockConfiguration": {
-                    "BlockPublicAcls": "true",
-                    "BlockPublicPolicy": "true",
-                    "IgnorePublicAcls": "true",
-                    "RestrictPublicBuckets": "true"
-                },
-                "VersioningConfiguration": {
-                    "Status": "Enabled"
-                }
-            },
-            "Type": "AWS::S3::Bucket"
         },
         "ElbProduction": {
-            "DependsOn": "ElbLogsBucketPolicyProduction",
+            "DependsOn": "ElbLogsBucketPolicy",
             "Properties": {
                 "AccessLoggingPolicy": {
                     "EmitInterval": 60,
                     "Enabled": true,
                     "S3BucketName": {
-                        "Ref": "ElbLogsBucketProduction"
-                    }
+                        "Ref": "ElbLogsBucket"
+                    },
+                    "S3BucketPrefix": "production"
                 },
                 "CrossZone": "true",
                 "HealthCheck": {
@@ -1309,14 +1221,15 @@
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
         },
         "ElbStaging": {
-            "DependsOn": "ElbLogsBucketPolicyStaging",
+            "DependsOn": "ElbLogsBucketPolicy",
             "Properties": {
                 "AccessLoggingPolicy": {
                     "EmitInterval": 60,
                     "Enabled": true,
                     "S3BucketName": {
-                        "Ref": "ElbLogsBucketStaging"
-                    }
+                        "Ref": "ElbLogsBucket"
+                    },
+                    "S3BucketPrefix": "staging"
                 },
                 "CrossZone": "true",
                 "HealthCheck": {
@@ -1530,7 +1443,7 @@
                     "DestinationBucketName": {
                         "Ref": "BucketLogsBucket"
                     },
-                    "LogFilePrefix": "ProductionPrivate"
+                    "LogFilePrefix": "ProductionPrivate/"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",
@@ -1605,7 +1518,7 @@
                     "DestinationBucketName": {
                         "Ref": "BucketLogsBucket"
                     },
-                    "LogFilePrefix": "StagingPrivate"
+                    "LogFilePrefix": "StagingPrivate/"
                 },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": "true",

--- a/vpc-template/setup.cfg
+++ b/vpc-template/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length=120
+
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/vpc-template/stack/__init__.py
+++ b/vpc-template/stack/__init__.py
@@ -1,0 +1,8 @@
+from . import assets  # noqa: F401
+from . import vpc  # noqa: F401
+from . import template
+from . import instances  # noqa: F401
+from . import networking  # noqa: F401
+from . import load_balancer  # noqa: F401
+
+print(template.template.to_json())

--- a/vpc-template/stack/assets.py
+++ b/vpc-template/stack/assets.py
@@ -1,0 +1,317 @@
+from troposphere import (
+    AWS_REGION,
+    And,
+    Equals,
+    GetAtt,
+    If,
+    Join,
+    Not,
+    Output,
+    Ref,
+    Split,
+    iam,
+)
+from troposphere.certificatemanager import Certificate, DomainValidationOption
+from troposphere.cloudfront import (
+    DefaultCacheBehavior,
+    Distribution,
+    DistributionConfig,
+    ForwardedValues,
+    Origin,
+    S3OriginConfig,
+    ViewerCertificate,
+)
+from troposphere.s3 import (
+    Bucket,
+    BucketEncryption,
+    CorsConfiguration,
+    CorsRules,
+    Private,
+    PublicAccessBlockConfiguration,
+    PublicRead,
+    ServerSideEncryptionByDefault,
+    ServerSideEncryptionRule,
+    VersioningConfiguration,
+)
+
+from .common import arn_prefix, environments
+from .domain import domain_name, domain_name_alternates, no_alt_domains
+from .template import template
+from .utils import ParameterWithDefaults as Parameter
+
+use_aes256_encryption = template.add_parameter(
+    Parameter(
+        "AssetsUseAES256Encryption",
+        Description="Whether or not to use server side encryption for S3 buckets. "
+        "When true, AES256 encryption is enabled for all asset buckets.",
+        Type="String",
+        AllowedValues=["true", "false"],
+        Default="true",
+    ),
+    group="Static Media",
+    label="Enable AES256 Encryption",
+)
+use_aes256_encryption_cond = "AssetsUseS3EncryptionCondition"
+template.add_condition(
+    use_aes256_encryption_cond, Equals(Ref(use_aes256_encryption), "true")
+)
+
+common_bucket_conf = dict(
+    BucketEncryption=BucketEncryption(
+        ServerSideEncryptionConfiguration=If(
+            use_aes256_encryption_cond,
+            [
+                ServerSideEncryptionRule(
+                    ServerSideEncryptionByDefault=ServerSideEncryptionByDefault(
+                        SSEAlgorithm="AES256"
+                    )
+                )
+            ],
+            [ServerSideEncryptionRule()],
+        )
+    ),
+    VersioningConfiguration=VersioningConfiguration(Status="Enabled"),
+    DeletionPolicy="Retain",
+    CorsConfiguration=CorsConfiguration(
+        CorsRules=[
+            CorsRules(
+                AllowedOrigins=Split(
+                    ";",
+                    Join(
+                        "",
+                        [
+                            "https://",
+                            domain_name,
+                            If(
+                                no_alt_domains,
+                                # if we don't have any alternate domains, return an empty string
+                                "",
+                                # otherwise, return the ';https://' that will be needed by the first domain
+                                ";https://",
+                            ),
+                            # then, add all the alternate domains, joined together with ';https://'
+                            Join(";https://", domain_name_alternates),
+                            # now that we have a string of origins separated by ';',
+                            # Split() is used to make it into a list again
+                        ],
+                    ),
+                ),
+                AllowedMethods=["POST", "PUT", "HEAD", "GET"],
+                AllowedHeaders=["*"],
+            )
+        ]
+    ),
+)
+
+assets_buckets = []
+private_buckets = []
+
+for environment in environments:
+    # Create an S3 bucket that holds statics and media
+    assets_bucket = template.add_resource(
+        Bucket(
+            "AssetsBucket%s" % environment.title(),
+            AccessControl=PublicRead,
+            **common_bucket_conf,
+        )
+    )
+    # Output S3 asset bucket name
+    template.add_output(
+        Output(
+            "AssetsBucket%sDomainName" % environment.title(),
+            Description="Assets bucket domain name (%s)" % environment,
+            Value=GetAtt(assets_bucket, "DomainName"),
+        )
+    )
+    assets_buckets.append(assets_bucket)
+    # Create an S3 bucket that holds user uploads or other non-public files
+    private_bucket = template.add_resource(
+        Bucket(
+            "PrivateBucket%s" % environment.title(),
+            AccessControl=Private,
+            PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
+                IgnorePublicAcls=True
+            ),
+            **common_bucket_conf,
+        )
+    )
+    # Output S3 asset bucket name
+    template.add_output(
+        Output(
+            "PrivateBucket%sDomainName" % environment.title(),
+            Description="Private bucket domain name (%s)" % environment,
+            Value=GetAtt(private_bucket, "DomainName"),
+        )
+    )
+    private_buckets.append(private_bucket)
+
+
+# central asset management policy for use in instance roles
+assets_management_policy = iam.Policy(
+    PolicyName="AssetsManagementPolicy",
+    PolicyDocument=dict(
+        Statement=[
+            *[
+                dict(
+                    Effect="Allow",
+                    Action=["s3:ListBucket"],
+                    Resource=Join("", [arn_prefix, ":s3:::", Ref(bucket)]),
+                )
+                for bucket in assets_buckets + private_buckets
+            ],
+            *[
+                dict(
+                    Effect="Allow",
+                    Action=["s3:*"],
+                    Resource=Join("", [arn_prefix, ":s3:::", Ref(bucket), "/*"]),
+                )
+                for bucket in assets_buckets + private_buckets
+            ],
+        ]
+    ),
+)
+
+
+distributions = []
+
+assets_use_cloudfront = template.add_parameter(
+    Parameter(
+        "AssetsUseCloudFront",
+        Description="Whether or not to create a CloudFront distribution tied to the S3 assets bucket.",
+        Type="String",
+        AllowedValues=["true", "false"],
+        Default="true",
+    ),
+    group="Static Media",
+    label="Enable CloudFront",
+)
+assets_use_cloudfront_condition = "AssetsUseCloudFrontCondition"
+template.add_condition(
+    assets_use_cloudfront_condition, Equals(Ref(assets_use_cloudfront), "true")
+)
+
+assets_cloudfront_domain = template.add_parameter(
+    Parameter(
+        "AssetsCloudFrontDomain",
+        Description="A custom domain name (CNAME) for your CloudFront distribution, e.g., "
+        '"static.example.com".',
+        Type="String",
+        Default="",
+    ),
+    group="Static Media",
+    label="CloudFront Custom Domain",
+)
+assets_custom_domain_condition = "AssetsCloudFrontDomainCondition"
+template.add_condition(
+    assets_custom_domain_condition, Not(Equals(Ref(assets_cloudfront_domain), ""))
+)
+
+# Currently, you can specify only certificates that are in the US East (N. Virginia) region.
+# http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-viewercertificate.html
+assets_custom_domain_and_us_east_1_condition = (
+    "AssetsCloudFrontDomainAndUsEast1Condition"
+)
+template.add_condition(
+    assets_custom_domain_and_us_east_1_condition,
+    And(
+        Not(Equals(Ref(assets_cloudfront_domain), "")),
+        Equals(Ref(AWS_REGION), "us-east-1"),
+    ),
+)
+
+assets_certificate = template.add_resource(
+    Certificate(
+        "AssetsCertificate",
+        Condition=assets_custom_domain_and_us_east_1_condition,
+        DomainName=Ref(assets_cloudfront_domain),
+        DomainValidationOptions=[
+            DomainValidationOption(
+                DomainName=Ref(assets_cloudfront_domain),
+                ValidationDomain=Ref(assets_cloudfront_domain),
+            )
+        ],
+    )
+)
+
+assets_certificate_arn = template.add_parameter(
+    Parameter(
+        "AssetsCloudFrontCertArn",
+        Description="If (1) you specified a custom static media domain, (2) your stack is NOT in the us-east-1 "
+        "region, and (3) you wish to serve static media over HTTPS, you must manually create an "
+        "ACM certificate in the us-east-1 region and provide its ARN here.",
+        Type="String",
+    ),
+    group="Static Media",
+    label="CloudFront SSL Certificate ARN",
+)
+assets_certificate_arn_condition = "AssetsCloudFrontCertArnCondition"
+template.add_condition(
+    assets_certificate_arn_condition, Not(Equals(Ref(assets_certificate_arn), ""))
+)
+
+for environment in environments:
+    # Create a CloudFront CDN distribution
+    distribution = template.add_resource(
+        Distribution(
+            "AssetsDistribution%s" % environment.title(),
+            Condition=assets_use_cloudfront_condition,
+            DistributionConfig=DistributionConfig(
+                Aliases=If(
+                    assets_custom_domain_condition,
+                    [Ref(assets_cloudfront_domain)],
+                    Ref("AWS::NoValue"),
+                ),
+                # use the ACM certificate we created (if any), otherwise fall back to the manually-supplied
+                # ARN (if any)
+                ViewerCertificate=If(
+                    assets_custom_domain_and_us_east_1_condition,
+                    ViewerCertificate(
+                        AcmCertificateArn=Ref(assets_certificate),
+                        SslSupportMethod="sni-only",
+                    ),
+                    If(
+                        assets_certificate_arn_condition,
+                        ViewerCertificate(
+                            AcmCertificateArn=Ref(assets_certificate_arn),
+                            SslSupportMethod="sni-only",
+                        ),
+                        Ref("AWS::NoValue"),
+                    ),
+                ),
+                Origins=[
+                    Origin(
+                        Id="Assets",
+                        DomainName=GetAtt(assets_bucket, "DomainName"),
+                        S3OriginConfig=S3OriginConfig(OriginAccessIdentity=""),
+                    )
+                ],
+                DefaultCacheBehavior=DefaultCacheBehavior(
+                    TargetOriginId="Assets",
+                    ForwardedValues=ForwardedValues(
+                        # Cache results *should* vary based on querystring (e.g., 'style.css?v=3')
+                        QueryString=True,
+                        # make sure headers needed by CORS policy above get through to S3
+                        # http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web-cors
+                        Headers=[
+                            "Origin",
+                            "Access-Control-Request-Headers",
+                            "Access-Control-Request-Method",
+                        ],
+                    ),
+                    ViewerProtocolPolicy="allow-all",
+                ),
+                Enabled=True,
+            ),
+        )
+    )
+
+    # Output CloudFront url
+    template.add_output(
+        Output(
+            "AssetsDistribution%sDomainName" % environment.title(),
+            Description="The assets bucket CDN domain name (%s)" % environment,
+            Value=GetAtt(distribution, "DomainName"),
+            Condition=assets_use_cloudfront_condition,
+        )
+    )
+    distributions.append(distribution)

--- a/vpc-template/stack/assets.py
+++ b/vpc-template/stack/assets.py
@@ -28,7 +28,6 @@ from troposphere.s3 import (
     CorsRules,
     Private,
     PublicAccessBlockConfiguration,
-    PublicRead,
     ServerSideEncryptionByDefault,
     ServerSideEncryptionRule,
     VersioningConfiguration,
@@ -111,7 +110,7 @@ for environment in environments:
     assets_bucket = template.add_resource(
         Bucket(
             "AssetsBucket%s" % environment.title(),
-            AccessControl=PublicRead,
+            AccessControl=Private,  # Objects can still be made public
             **common_bucket_conf,
         )
     )
@@ -130,7 +129,10 @@ for environment in environments:
             "PrivateBucket%s" % environment.title(),
             AccessControl=Private,
             PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
-                IgnorePublicAcls=True
+                BlockPublicAcls=True,
+                BlockPublicPolicy=True,
+                IgnorePublicAcls=True,
+                RestrictPublicBuckets=True,
             ),
             **common_bucket_conf,
         )

--- a/vpc-template/stack/common.py
+++ b/vpc-template/stack/common.py
@@ -1,0 +1,11 @@
+from troposphere import AWS_REGION, Equals, If, Ref
+
+from .template import template
+
+environments = ["staging", "production"]
+
+dont_create_value = "(none)"
+
+in_govcloud_region = "InGovCloudRegion"
+template.add_condition(in_govcloud_region, Equals(Ref(AWS_REGION), "us-gov-west-1"))
+arn_prefix = If(in_govcloud_region, "arn:aws-us-gov", "arn:aws")

--- a/vpc-template/stack/common.py
+++ b/vpc-template/stack/common.py
@@ -2,7 +2,7 @@ from troposphere import AWS_REGION, Equals, If, Ref
 
 from .template import template
 
-environments = ["staging", "production"]
+environments = ["testing", "staging", "production"]
 
 dont_create_value = "(none)"
 

--- a/vpc-template/stack/domain.py
+++ b/vpc-template/stack/domain.py
@@ -1,35 +1,20 @@
-from troposphere import Equals, Join, Ref
+from troposphere import Ref
 
+from .common import environments
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
 
-domain_name = Ref(
-    template.add_parameter(
-        Parameter(
-            "DomainName",
-            Description="The fully-qualified domain name for the application.",
-            Type="String",
-        ),
-        group="Global",
-        label="Domain Name",
-    )
-)
 
-domain_name_alternates = Ref(
-    template.add_parameter(
-        Parameter(
-            "DomainNameAlternates",
-            Description="A comma-separated list of Alternate FQDNs.",
-            Type="CommaDelimitedList",
-        ),
-        group="Global",
-        label="Alternate Domain Names",
+domains = {}
+for environment in environments:
+    domains[environment] = Ref(
+        template.add_parameter(
+            Parameter(
+                "DomainNames%s" % environment.title(),
+                Description="A comma-separated list of FQDNs for %s." % environment,
+                Type="CommaDelimitedList",
+            ),
+            group="Global",
+            label="Domain Names (%s)" % environment,
+        )
     )
-)
-
-no_alt_domains = "NoAlternateDomains"
-template.add_condition(
-    no_alt_domains,
-    # Equals() only supports strings, so convert domain_name_alternates to one first
-    Equals(Join("", domain_name_alternates), ""),
-)

--- a/vpc-template/stack/domain.py
+++ b/vpc-template/stack/domain.py
@@ -1,0 +1,35 @@
+from troposphere import Equals, Join, Ref
+
+from .template import template
+from .utils import ParameterWithDefaults as Parameter
+
+domain_name = Ref(
+    template.add_parameter(
+        Parameter(
+            "DomainName",
+            Description="The fully-qualified domain name for the application.",
+            Type="String",
+        ),
+        group="Global",
+        label="Domain Name",
+    )
+)
+
+domain_name_alternates = Ref(
+    template.add_parameter(
+        Parameter(
+            "DomainNameAlternates",
+            Description="A comma-separated list of Alternate FQDNs.",
+            Type="CommaDelimitedList",
+        ),
+        group="Global",
+        label="Alternate Domain Names",
+    )
+)
+
+no_alt_domains = "NoAlternateDomains"
+template.add_condition(
+    no_alt_domains,
+    # Equals() only supports strings, so convert domain_name_alternates to one first
+    Equals(Join("", domain_name_alternates), ""),
+)

--- a/vpc-template/stack/instances.py
+++ b/vpc-template/stack/instances.py
@@ -17,7 +17,7 @@ from .load_balancer import load_balancers
 from .logs import logging_policy
 from .security_groups import router_security_group, web_security_group
 from .template import template
-from .vpc import private_a_subnet, private_b_subnet, public_a_subnet
+from .vpc import private_subnet_a, private_subnet_b, public_subnet_a
 
 router_ami = template.add_parameter(
     Parameter(
@@ -90,7 +90,7 @@ ec2_instance_definitions = {
     ("router", ""): dict(
         ImageId=Ref(router_ami),
         SecurityGroupIds=[Ref(router_security_group)],
-        SubnetId=Ref(public_a_subnet),
+        SubnetId=Ref(public_subnet_a),
         # https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html#EIP_Disable_SrcDestCheck
         SourceDestCheck=False,
         # Prevent accidental deletion of the router (in case this stack ever needs to be deleted,
@@ -165,7 +165,7 @@ for environment in environments:
     autoscaling_group = autoscaling.AutoScalingGroup(
         autoscaling_group_name,
         template=template,
-        VPCZoneIdentifier=[Ref(private_a_subnet), Ref(private_b_subnet)],
+        VPCZoneIdentifier=[Ref(private_subnet_a), Ref(private_subnet_b)],
         # Start with no instances (will be added by fabulaws)
         MinSize="0",
         MaxSize="32",

--- a/vpc-template/stack/instances.py
+++ b/vpc-template/stack/instances.py
@@ -1,0 +1,188 @@
+from troposphere import (
+    AWS_STACK_NAME,
+    GetAtt,
+    Join,
+    Output,
+    Parameter,
+    Ref,
+    Tags,
+    autoscaling,
+    ec2,
+    iam,
+)
+
+from .assets import assets_management_policy
+from .common import environments
+from .load_balancer import load_balancer
+from .logs import logging_policy
+from .security_groups import router_security_group, web_security_group
+from .template import template
+from .vpc import private_a_subnet, private_b_subnet, public_a_subnet
+
+router_ami = template.add_parameter(
+    Parameter(
+        "RouterAMI",
+        Description="pfSense AMI from the AWS marketplace in the same region as this stack",
+        Type="String",
+        Default="ami-089c333c4d9b09ffc",  # us-east-1
+    ),
+    group="EC2",
+    label="Router AMI",
+)
+
+key_name = template.add_parameter(
+    Parameter(
+        "KeyName",
+        Description="Name of an existing EC2 KeyPair to enable SSH access to "
+        "the AWS EC2 instances",
+        Type="AWS::EC2::KeyPair::KeyName",
+        ConstraintDescription="must be the name of an existing EC2 KeyPair.",
+    ),
+    group="EC2",
+    label="SSH Key Name",
+)
+
+# # EC2 instance role
+# instance_role = iam.Role(
+#     "InstanceRole",
+#     template=template,
+#     AssumeRolePolicyDocument=dict(
+#         Statement=[
+#             dict(
+#                 Effect="Allow",
+#                 Principal=dict(Service=["ec2.amazonaws.com"]),
+#                 Action=["sts:AssumeRole"],
+#             )
+#         ]
+#     ),
+#     Path="/",
+#     Policies=[assets_management_policy, logging_policy],
+# )
+
+# # EC2 instance profile
+# instance_profile = iam.InstanceProfile(
+#     "InstanceProfile", template=template, Path="/", Roles=[Ref(instance_role)]
+# )
+
+# Root Volume Sizes
+# These are just the defaults. Typically these values should not be changed, as
+# doing so will result in instance recreation. Instead you can increase the size
+# of the EBS volume via the AWS console (followed by resize2fs on the instance):
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/requesting-ebs-volume-modifications.html#modify-ebs-volume
+ROOT_VOLUME_SIZES = {"router": 8}
+
+# Instance Types
+# See: https://aws.amazon.com/blogs/aws/new-t2-xlarge-and-t2-2xlarge-instances/
+INSTANCE_TYPES = {("router", ""): "t2.nano"}
+
+
+def ebs_block_device(volume_size):
+    return [
+        ec2.BlockDeviceMapping(
+            DeviceName="/dev/sda1", Ebs=ec2.EBSBlockDevice(VolumeSize=volume_size)
+        )
+    ]
+
+
+common_ec2_properties = dict(
+    KeyName=Ref(key_name),
+    # IamInstanceProfile=Ref(instance_profile)
+)
+
+ec2_instance_definitions = {
+    ("router", ""): dict(
+        ImageId=Ref(router_ami),
+        SecurityGroupIds=[Ref(router_security_group)],
+        SubnetId=Ref(public_a_subnet),
+        # https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html#EIP_Disable_SrcDestCheck
+        SourceDestCheck=False,
+        # Prevent accidental deletion of the router (in case this stack ever needs to be deleted,
+        # one may need to set this to False first).
+        DisableApiTermination=True,
+    )
+}
+
+created_instances = {}
+
+for (name, environment), properties in ec2_instance_definitions.items():
+    default_properties = dict(common_ec2_properties)
+    # remove all digits from the instance name (to simplify volume size / instance type lookups)
+    name_no_digits = name.translate(str.maketrans("", "", "1234567890"))
+    default_properties.update(
+        dict(
+            BlockDeviceMappings=ebs_block_device(ROOT_VOLUME_SIZES[name_no_digits]),
+            InstanceType=INSTANCE_TYPES[(name_no_digits, environment)],
+        )
+    )
+    # make sure any instance-specific properties override the common/defaults
+    default_properties.update(properties)
+    instance_name = "{}{}".format(environment, name)
+    created_instances[(name, environment)] = template.add_resource(
+        ec2.Instance(
+            title=instance_name,
+            Tags=Tags(
+                Name=Join("-", [Ref("AWS::StackName"), instance_name]),
+                Environment=environment,
+            ),
+            **default_properties
+        )
+    )
+
+# Associate the Elastic IP separately, so it doesn't change when the instance changes.
+router_eip = template.add_resource(ec2.EIP("RouterEIP", Domain="vpc"))
+template.add_resource(
+    ec2.EIPAssociation(
+        "RouterEipAssociation",
+        InstanceId=Ref(created_instances[("router", "")]),
+        # Might need to switch the following line to EIP=Ref(router_eip) if
+        # we ever create this stack in a VPC-only account.
+        AllocationId=GetAtt(router_eip, "AllocationId"),
+    )
+)
+
+template.add_output(
+    [
+        Output(
+            "RouterPublicIP",
+            Description="Public IP address of router",
+            Value=Ref(router_eip),
+        )
+    ]
+)
+
+for environment in environments:
+    instance_configuration_name = "LaunchConfiguration%s" % environment.title()
+    autoscaling_group_name = "AutoScalingGroup%s" % environment.title()
+
+    container_instance_configuration = autoscaling.LaunchConfiguration(
+        instance_configuration_name,
+        template=template,
+        SecurityGroups=[Ref(web_security_group)],
+        # We need a launch config to create an autoscaling group, so just use the router AMI/instance type.
+        # We set the DesiredCapacity to 0 below, so none of these will actually get created.
+        InstanceType=INSTANCE_TYPES[("router", "")],
+        ImageId=Ref(router_ami),
+        # IamInstanceProfile=Ref(instance_profile),
+        KeyName=Ref(key_name),
+    )
+
+    autoscaling_group = autoscaling.AutoScalingGroup(
+        autoscaling_group_name,
+        template=template,
+        VPCZoneIdentifier=[Ref(private_a_subnet), Ref(private_b_subnet)],
+        # Start with no instances (will be added by fabulaws)
+        MinSize="0",
+        MaxSize="32",
+        DesiredCapacity="0",
+        LaunchConfigurationName=Ref(container_instance_configuration),
+        LoadBalancerNames=[Ref(load_balancer)],
+        HealthCheckType="EC2",
+        HealthCheckGracePeriod=300,
+        Tags=[
+            {
+                "Key": "Name",
+                "Value": Join("-", [Ref(AWS_STACK_NAME), "web_worker"]),
+                "PropagateAtLaunch": True,
+            }
+        ],
+    )

--- a/vpc-template/stack/instances.py
+++ b/vpc-template/stack/instances.py
@@ -84,10 +84,7 @@ def ebs_block_device(volume_size):
     ]
 
 
-common_ec2_properties = dict(
-    KeyName=Ref(key_name),
-    # IamInstanceProfile=Ref(instance_profile)
-)
+common_ec2_properties = dict(KeyName=Ref(key_name))
 
 ec2_instance_definitions = {
     ("router", ""): dict(
@@ -162,7 +159,6 @@ for environment in environments:
         # We set the DesiredCapacity to 0 below, so none of these will actually get created.
         InstanceType=INSTANCE_TYPES[("router", "")],
         ImageId=Ref(router_ami),
-        # IamInstanceProfile=Ref(instance_profile),
         KeyName=Ref(key_name),
     )
 
@@ -173,7 +169,7 @@ for environment in environments:
         # Start with no instances (will be added by fabulaws)
         MinSize="0",
         MaxSize="32",
-        DesiredCapacity="0",
+        # Don't specify DesiredCapacity to avoid updating that attribute
         LaunchConfigurationName=Ref(container_instance_configuration),
         LoadBalancerNames=[Ref(load_balancer)],
         HealthCheckType="EC2",

--- a/vpc-template/stack/instances.py
+++ b/vpc-template/stack/instances.py
@@ -13,7 +13,7 @@ from troposphere import (
 
 from .assets import assets_management_policy
 from .common import environments
-from .load_balancer import load_balancer
+from .load_balancer import load_balancers
 from .logs import logging_policy
 from .security_groups import router_security_group, web_security_group
 from .template import template
@@ -171,8 +171,8 @@ for environment in environments:
         MaxSize="32",
         # Don't specify DesiredCapacity to avoid updating that attribute
         LaunchConfigurationName=Ref(container_instance_configuration),
-        LoadBalancerNames=[Ref(load_balancer)],
-        HealthCheckType="EC2",
+        LoadBalancerNames=[Ref(load_balancers[environment])],
+        HealthCheckType="ELB",
         HealthCheckGracePeriod=300,
         Tags=[
             {

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -117,6 +117,7 @@ for environment in environments:
         ),
         Instances=[],  # will be added by fabulaws
         CrossZone=True,
+        DependsOn=bucket_policy,
     )
 
     template.add_output(

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -55,8 +55,8 @@ for environment in environments:
         # If ACM is enabled, use the certificate here, otherwise pass TCP connections directly
         elb.Listener(
             LoadBalancerPort=443,
-            InstanceProtocol=If(acm_cert_condition, "HTTP", "TCP"),
-            InstancePort=80,
+            InstanceProtocol=If(acm_cert_condition, "HTTPS", "TCP"),
+            InstancePort=443,
             Protocol=If(acm_cert_condition, "HTTPS", "TCP"),
             SSLCertificateId=If(acm_cert_condition, acm_cert_arn, Ref("AWS::NoValue")),
         ),

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -20,7 +20,8 @@ web_worker_health_check = Ref(
     )
 )
 
-# Web load balancer
+# Web load balancers
+load_balancers = {}
 
 for environment in environments:
     acm_cert_arn = Ref(
@@ -62,7 +63,7 @@ for environment in environments:
         ),
     ]
 
-    load_balancer = elb.LoadBalancer(
+    load_balancers[environment] = elb.LoadBalancer(
         "LoadBalancer%s" % environment.title(),
         template=template,
         Subnets=[Ref(public_a_subnet), Ref(public_b_subnet)],
@@ -87,6 +88,6 @@ for environment in environments:
         Output(
             "LoadBalancer%sDNSName" % environment.title(),
             Description="Loadbalancer DNS",
-            Value=GetAtt(load_balancer, "DNSName"),
+            Value=GetAtt(load_balancers[environment], "DNSName"),
         )
     )

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -4,7 +4,7 @@ from troposphere import Equals, GetAtt, If, Join, Not, Output, Parameter, Ref
 from .common import environments
 from .security_groups import aws_elb_security_group
 from .template import template
-from .vpc import public_a_subnet, public_b_subnet
+from .vpc import public_subnet_a, public_subnet_b
 
 web_worker_health_check = Ref(
     template.add_parameter(
@@ -66,7 +66,7 @@ for environment in environments:
     load_balancers[environment] = elb.LoadBalancer(
         "Elb%s" % environment.title(),
         template=template,
-        Subnets=[Ref(public_a_subnet), Ref(public_b_subnet)],
+        Subnets=[Ref(public_subnet_a), Ref(public_subnet_b)],
         SecurityGroups=[Ref(aws_elb_security_group)],
         Listeners=listeners,
         HealthCheck=elb.HealthCheck(

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -1,0 +1,92 @@
+from troposphere import elasticloadbalancing as elb
+from troposphere import Equals, GetAtt, If, Join, Not, Output, Parameter, Ref
+
+from .common import environments
+from .security_groups import aws_elb_security_group
+from .template import template
+from .vpc import public_a_subnet, public_b_subnet
+
+web_worker_health_check = Ref(
+    template.add_parameter(
+        Parameter(
+            "WebWorkerHealthCheck",
+            Description='Web worker health check URL path, e.g., "/health-check"; '
+            "will default to TCP-only health check if left blank",
+            Type="String",
+            Default="",
+        ),
+        group="Load Balancer",
+        label="Health Check URL",
+    )
+)
+
+# Web load balancer
+
+for environment in environments:
+    acm_cert_arn = Ref(
+        template.add_parameter(
+            Parameter(
+                "AcmCertArn%s" % environment.title(),
+                Description="ARN of the AWS Certificate Manager certificate (optional). If omitted, TCP "
+                "connections will be passed directly to the backend instances on port 443.",
+                Type="String",
+                Default="",
+            ),
+            group="Load Balancer",
+            label="ACM Certificate ARN (%s)" % environment,
+        )
+    )
+
+    tcp_health_check_condition = "TcpHealthCheck%s" % environment.title()
+    template.add_condition(
+        tcp_health_check_condition, Equals(web_worker_health_check, "")
+    )
+
+    acm_cert_condition = "AcmCertCondition%s" % environment.title()
+    template.add_condition(acm_cert_condition, Not(Equals(acm_cert_arn, "")))
+
+    listeners = [
+        elb.Listener(
+            LoadBalancerPort=80,
+            InstanceProtocol="HTTP",
+            InstancePort=80,
+            Protocol="HTTP",
+        ),
+        # If ACM is enabled, use the certificate here, otherwise pass TCP connections directly
+        elb.Listener(
+            LoadBalancerPort=443,
+            InstanceProtocol=If(acm_cert_condition, "HTTP", "TCP"),
+            InstancePort=80,
+            Protocol=If(acm_cert_condition, "HTTPS", "TCP"),
+            SSLCertificateId=If(acm_cert_condition, acm_cert_arn, Ref("AWS::NoValue")),
+        ),
+    ]
+
+    load_balancer = elb.LoadBalancer(
+        "LoadBalancer%s" % environment.title(),
+        template=template,
+        Subnets=[Ref(public_a_subnet), Ref(public_b_subnet)],
+        SecurityGroups=[Ref(aws_elb_security_group)],
+        Listeners=listeners,
+        HealthCheck=elb.HealthCheck(
+            Target=If(
+                tcp_health_check_condition,
+                "TCP:80",
+                Join("", ["HTTPS:80", web_worker_health_check]),
+            ),
+            HealthyThreshold="2",
+            UnhealthyThreshold="2",
+            Interval="10",
+            Timeout="9",
+        ),
+        Instances=[],  # will be added by fabulaws
+        CrossZone=True,
+    )
+
+    template.add_output(
+        Output(
+            "LoadBalancer%sDNSName" % environment.title(),
+            Description="Loadbalancer DNS",
+            Value=GetAtt(load_balancer, "DNSName"),
+        )
+    )

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -6,18 +6,16 @@ from .security_groups import aws_elb_security_group
 from .template import template
 from .vpc import public_subnet_a, public_subnet_b
 
-web_worker_health_check = Ref(
-    template.add_parameter(
-        Parameter(
-            "WebWorkerHealthCheck",
-            Description='Web worker health check URL path, e.g., "/health-check"; '
-            "will default to TCP-only health check if left blank",
-            Type="String",
-            Default="",
-        ),
-        group="Load Balancer",
-        label="Health Check URL",
-    )
+web_worker_health_check = template.add_parameter(
+    Parameter(
+        "WebWorkerHealthCheck",
+        Description='Web worker health check URL path, e.g., "/health-check"; '
+        "will default to TCP-only health check if left blank",
+        Type="String",
+        Default="",
+    ),
+    group="Load Balancer",
+    label="Health Check URL",
 )
 
 # Web load balancers
@@ -40,7 +38,7 @@ for environment in environments:
 
     tcp_health_check_condition = "TcpHealthCheck%s" % environment.title()
     template.add_condition(
-        tcp_health_check_condition, Equals(web_worker_health_check, "")
+        tcp_health_check_condition, Equals(Ref(web_worker_health_check), "")
     )
 
     acm_cert_condition = "AcmCertCondition%s" % environment.title()
@@ -73,7 +71,7 @@ for environment in environments:
             Target=If(
                 tcp_health_check_condition,
                 "TCP:80",
-                Join("", ["HTTPS:443", web_worker_health_check]),
+                Join("", ["HTTPS:443", Ref(web_worker_health_check)]),
             ),
             HealthyThreshold="2",
             UnhealthyThreshold="2",

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -72,7 +72,7 @@ for environment in environments:
             Target=If(
                 tcp_health_check_condition,
                 "TCP:80",
-                Join("", ["HTTPS:80", web_worker_health_check]),
+                Join("", ["HTTPS:443", web_worker_health_check]),
             ),
             HealthyThreshold="2",
             UnhealthyThreshold="2",

--- a/vpc-template/stack/load_balancer.py
+++ b/vpc-template/stack/load_balancer.py
@@ -64,7 +64,7 @@ for environment in environments:
     ]
 
     load_balancers[environment] = elb.LoadBalancer(
-        "LoadBalancer%s" % environment.title(),
+        "Elb%s" % environment.title(),
         template=template,
         Subnets=[Ref(public_a_subnet), Ref(public_b_subnet)],
         SecurityGroups=[Ref(aws_elb_security_group)],
@@ -86,7 +86,7 @@ for environment in environments:
 
     template.add_output(
         Output(
-            "LoadBalancer%sDNSName" % environment.title(),
+            "Elb%sDnsName" % environment.title(),
             Description="Loadbalancer DNS",
             Value=GetAtt(load_balancers[environment], "DNSName"),
         )

--- a/vpc-template/stack/logs.py
+++ b/vpc-template/stack/logs.py
@@ -1,0 +1,35 @@
+from troposphere import AWS_REGION, Join, Ref, iam, logs
+
+from .common import arn_prefix
+from .template import template
+
+log_group = logs.LogGroup(
+    "LogGroup",
+    template=template,
+    RetentionInDays=731,  # 2 years
+    DeletionPolicy="Retain",
+)
+
+
+logging_policy = iam.Policy(
+    PolicyName="LoggingPolicy",
+    PolicyDocument=dict(
+        Statement=[
+            dict(
+                Effect="Allow",
+                Action=["logs:Create*", "logs:PutLogEvents"],
+                Resource=Join(
+                    "",
+                    [
+                        arn_prefix,
+                        ":logs:",
+                        Ref(AWS_REGION),
+                        ":*:log-group:",
+                        Ref(log_group),  # allow logging to this log group only
+                        ":*",
+                    ],
+                ),
+            )
+        ]
+    ),
+)

--- a/vpc-template/stack/networking.py
+++ b/vpc-template/stack/networking.py
@@ -1,0 +1,22 @@
+from troposphere import Ref, ec2
+
+from .instances import created_instances
+from .template import template
+from .vpc import nat_gateway, private_route_table
+
+if nat_gateway:
+    private_nat_route = ec2.Route(
+        "PrivateNatRoute",
+        template=template,
+        RouteTableId=Ref(private_route_table),
+        DestinationCidrBlock="0.0.0.0/0",
+        NatGatewayId=Ref(nat_gateway),
+    )
+else:
+    private_nat_route = ec2.Route(
+        "PrivateNatRoute",
+        template=template,
+        RouteTableId=Ref(private_route_table),
+        DestinationCidrBlock="0.0.0.0/0",
+        InstanceId=Ref(created_instances[("router", "")]),
+    )

--- a/vpc-template/stack/security_groups.py
+++ b/vpc-template/stack/security_groups.py
@@ -1,0 +1,109 @@
+from troposphere import Parameter, Ref
+from troposphere.ec2 import SecurityGroup, SecurityGroupIngress, SecurityGroupRule
+
+from .template import template
+from .vpc import vpc, vpc_cidr
+
+# CloudFormation uses -1 as a special value to signify 'ALL' in various parameters
+ALL = "-1"
+
+local_cidr = template.add_parameter(
+    Parameter(
+        "LocalCidr",
+        Description='CIDR block from which to allow restricted access. Set this to "<your IP>/32".',
+        Type="String",
+        Default="0.0.0.0/0",
+    ),
+    group="Networking",
+    label="Local CIDR",
+)
+
+# Only allow outside VPN access to the router
+router_security_group = template.add_resource(
+    SecurityGroup(
+        "RouterSecurityGroup",
+        GroupDescription="Allows SSH and HTTPS access from LocalCidr, and OpenVPN from anywhere.",
+        VpcId=Ref(vpc),
+        SecurityGroupIngress=[
+            SecurityGroupRule(
+                IpProtocol="tcp", FromPort=22, ToPort=22, CidrIp=Ref(local_cidr)
+            ),
+            SecurityGroupRule(
+                IpProtocol="tcp", FromPort=443, ToPort=443, CidrIp=Ref(local_cidr)
+            ),
+            SecurityGroupRule(
+                IpProtocol="udp", FromPort=1194, ToPort=1194, CidrIp="0.0.0.0/0"
+            ),
+            # Allow all traffic from our VPC, for NAT purposes
+            SecurityGroupRule(
+                IpProtocol=ALL, FromPort=ALL, ToPort=ALL, CidrIp=vpc_cidr
+            ),
+        ],
+    )
+)
+
+backend_security_group = template.add_resource(
+    SecurityGroup(
+        "BackendSecurityGroup",
+        GroupDescription="Allow full access between the Backend Instances",
+        VpcId=Ref(vpc),
+    )
+)
+# Allow unlimited traffic between all backend servers
+template.add_resource(
+    SecurityGroupIngress(
+        "BackendSecurityGroupIngressRule",
+        GroupId=Ref(backend_security_group),
+        IpProtocol=ALL,
+        SourceSecurityGroupId=Ref(backend_security_group),
+        FromPort=ALL,
+        ToPort=ALL,
+    )
+)
+# Allow unlimited traffic from router to backend servers
+template.add_resource(
+    SecurityGroupIngress(
+        "RouterToBackendSecurityGroupIngressRule",
+        GroupId=Ref(backend_security_group),
+        IpProtocol=ALL,
+        SourceSecurityGroupId=Ref(router_security_group),
+        FromPort=ALL,
+        ToPort=ALL,
+    )
+)
+
+aws_elb_security_group = SecurityGroup(
+    "AwsElbSecurityGroup",
+    template=template,
+    GroupDescription="AWS elastic load balancer security group.",
+    VpcId=Ref(vpc),
+    SecurityGroupIngress=[
+        # allow incoming traffic from the public internet to the AWS ELB on ports 80 and 443
+        SecurityGroupRule(
+            IpProtocol="tcp", FromPort=port, ToPort=port, CidrIp="0.0.0.0/0"
+        )
+        for port in ["80", "443"]
+    ],
+)
+
+web_security_group = SecurityGroup(
+    "WebServerSecurityGroup",
+    template=template,
+    GroupDescription="Backend web server security group.",
+    VpcId=Ref(vpc),
+    SecurityGroupIngress=[
+        # allow incoming traffic from the AWS ELB on ports 80 and 443 only
+        SecurityGroupRule(
+            IpProtocol="tcp",
+            FromPort="80",
+            ToPort="80",
+            SourceSecurityGroupId=Ref(aws_elb_security_group),
+        ),
+        SecurityGroupRule(
+            IpProtocol="tcp",
+            FromPort="443",
+            ToPort="443",
+            SourceSecurityGroupId=Ref(aws_elb_security_group),
+        ),
+    ],
+)

--- a/vpc-template/stack/security_groups.py
+++ b/vpc-template/stack/security_groups.py
@@ -36,7 +36,7 @@ router_security_group = template.add_resource(
             ),
             # Allow all traffic from our VPC, for NAT purposes
             SecurityGroupRule(
-                IpProtocol=ALL, FromPort=ALL, ToPort=ALL, CidrIp=vpc_cidr
+                IpProtocol=ALL, FromPort=ALL, ToPort=ALL, CidrIp=Ref(vpc_cidr)
             ),
         ],
     )

--- a/vpc-template/stack/template.py
+++ b/vpc-template/stack/template.py
@@ -1,0 +1,83 @@
+from collections import OrderedDict
+
+from troposphere import Template
+
+
+class InterfaceTemplate(Template):
+    """
+    Custom Template class that allows us to optionally define groups and labels for
+    CloudFormation Parameters at the time they're added to the template. Groups and
+    labels specified, if any, will be added to a custom AWS::CloudFormation::Interface
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(InterfaceTemplate, self).__init__(*args, **kwargs)
+        # use OrderedDict() so we can keep track of the order in which groups are added
+        self.parameter_groups = OrderedDict()
+        self.parameter_labels = {}
+        self.group_order = []
+
+    def add_parameter(self, parameter, group=None, label=None):
+        """
+        Save group and/or label, if specified, for later generation of
+        'AWS::CloudFormation::Interface' in to_dict().
+        """
+        parameter = super(InterfaceTemplate, self).add_parameter(parameter)
+        if group:
+            if group not in self.parameter_groups:
+                self.parameter_groups[group] = []
+            self.parameter_groups[group].append(parameter.title)
+        if label:
+            self.parameter_labels[parameter.title] = label
+        return parameter
+
+    def set_group_order(self, group_order):
+        """
+        Set an ordered list of all known, possible parameter groups in this stack.
+        If none is provided, groups will appear in the order they were first passed
+        to add_parameter().
+        """
+        self.group_order = group_order
+
+    def to_dict(self):
+        """
+        Overwrite 'AWS::CloudFormation::Interface' key in self.metadata (if any)
+        with the groups and labels defined via add_parameter(), and then call
+        super().to_dict().
+        """
+        # create an ordered list of parameter groups for our interface
+        ordered_groups = list(self.group_order)
+        groups_in_stack = list(self.parameter_groups.keys())
+        # add any groups specified in the stack that we didn't know about in advance
+        ordered_groups += [g for g in groups_in_stack if g not in ordered_groups]
+        # remove any groups NOT specified in the stack
+        ordered_groups = [g for g in ordered_groups if g in groups_in_stack]
+        # update metadata with our interface
+        self.metadata.update(
+            {
+                "AWS::CloudFormation::Interface": {
+                    "ParameterGroups": [
+                        {
+                            "Label": {"default": group},
+                            "Parameters": self.parameter_groups[group],
+                        }
+                        for group in ordered_groups
+                    ],
+                    "ParameterLabels": dict(
+                        [
+                            (parameter, {"default": label})
+                            for parameter, label in self.parameter_labels.items()
+                        ]
+                    ),
+                }
+            }
+        )
+        return super(InterfaceTemplate, self).to_dict()
+
+
+# The CloudFormation template
+template = InterfaceTemplate()
+
+# If you create a new group and care about the order in which it shows up in the
+# CloudFormation interface, add it below.
+template.set_group_order(["Global", "Application Server", "Load Balancer"])

--- a/vpc-template/stack/utils.py
+++ b/vpc-template/stack/utils.py
@@ -1,0 +1,60 @@
+"""
+Implement a way to override the parameter defaults in the .py files
+at stack template creation time by reading in a JSON file.
+
+At the end of this file, we look for an environment variable DEFAULTS_FILE
+and if it exists, read it in to initialize the defaults we want to override.
+"""
+
+import json
+import os
+
+from troposphere import Parameter as TroposphereParameter
+
+__ALL__ = ["ParameterWithDefaults", "set_defaults_from_dictionary"]
+
+parameter_defaults = {}
+
+
+class ParameterWithDefaults(TroposphereParameter):
+    """
+    Like a parameter, but you can change its default value by
+    loading different values in this module.
+    """
+
+    def __init__(self, title, **kwargs):
+        # If the parameter can accept a 'Default' parameter, and
+        # we have one configured, use that, overriding whatever was
+        # passed in.
+        if "Default" in self.props and title in parameter_defaults:
+            kwargs["Default"] = parameter_defaults[title]
+        super().__init__(title, **kwargs)
+
+
+def set_defaults_from_dictionary(d):
+    """
+    Update parameter default values from the given dictionary.
+    Dictionary should map parameter names to default values.
+
+    Example:
+
+        {
+            "AMI": "ami-078c57a94e9bdc6e0",
+            "AssetsUseCloudFront": "false",
+            "CacheNodeType": "(none)",
+            "ContainerInstanceType": "t2.medium",
+            "DatabaseClass": "db.t2.medium",
+            "DatabaseEngineVersion": "10.3",
+            "DatabaseStorageEncrypted": "true",
+            "DomainName": "example.caktus-built.com",
+            "KeyName": "id_example",
+            "MaxScale": "2",
+            "PrimaryAZ": "us-west-2a",
+            "SecondaryAZ": "us-west-2b"
+        }
+    """
+    parameter_defaults.update(d)
+
+
+if os.environ.get("DEFAULTS_FILE"):
+    set_defaults_from_dictionary(json.load(open(os.environ.get("DEFAULTS_FILE"))))

--- a/vpc-template/stack/vpc.py
+++ b/vpc-template/stack/vpc.py
@@ -1,6 +1,6 @@
 import os
 
-from troposphere import GetAtt, Parameter, Ref
+from troposphere import GetAtt, Join, Ref, Tags
 from troposphere.ec2 import (
     EIP,
     VPC,
@@ -14,8 +14,14 @@ from troposphere.ec2 import (
 )
 
 from .template import template
+from .utils import ParameterWithDefaults as Parameter
 
 USE_NAT_GATEWAY = os.environ.get("USE_NAT_GATEWAY") == "on"
+
+# Allows for private IPv4 ranges in the 10.0.0.0/8, 172.16.0.0/12 and 192.168.0.0/16
+# address spaces, with block size between /16 and /28 as allowed by VPCs and subnets.
+PRIVATE_IPV4_CIDR_REGEX = r"^((10\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)|(172\.(1[6-9]|2[0-9]|3[0-1])\.)|192\.168\.)(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$"  # noqa: E501
+PRIVATE_IPV4_CONSTRAINT = "Must be a private IPv4 range with size /16 and /28."
 
 primary_az = template.add_parameter(
     Parameter(
@@ -38,19 +44,97 @@ secondary_az = template.add_parameter(
     label="Secondary Availability Zone",
 )
 
+vpc_cidr = template.add_parameter(
+    Parameter(
+        "VpcCidr",
+        Description="The primary IPv4 CIDR block for the VPC. "
+                    "[Possibly not modifiable after stack creation]",
+        Type="String",
+        Default="10.0.0.0/20",
+        AllowedPattern=PRIVATE_IPV4_CIDR_REGEX,
+        ConstraintDescription=PRIVATE_IPV4_CONSTRAINT,
+    ),
+    group="Global",
+    label="VPC IPv4 CIDR Block",
+)
 
-vpc_cidr = "10.1.0.0/22"
+public_subnet_a_cidr = template.add_parameter(
+    Parameter(
+        "PublicSubnetACidr",
+        Description="IPv4 CIDR block for the public subnet in the primary AZ. "
+                    "[Possibly not modifiable after stack creation]",
+        Type="String",
+        Default="10.0.0.0/22",
+        AllowedPattern=PRIVATE_IPV4_CIDR_REGEX,
+        ConstraintDescription=PRIVATE_IPV4_CONSTRAINT,
+    ),
+    group="Global",
+    label="Public Subnet A CIDR Block",
+)
+
+public_subnet_b_cidr = template.add_parameter(
+    Parameter(
+        "PublicSubnetBCidr",
+        Description="IPv4 CIDR block for the public subnet in the secondary AZ. "
+                    "[Possibly not modifiable after stack creation]",
+        Type="String",
+        Default="10.0.4.0/22",
+        AllowedPattern=PRIVATE_IPV4_CIDR_REGEX,
+        ConstraintDescription=PRIVATE_IPV4_CONSTRAINT,
+    ),
+    group="Global",
+    label="Public Subnet B CIDR Block",
+)
+
+private_subnet_a_cidr = template.add_parameter(
+    Parameter(
+        "PrivateSubnetACidr",
+        Description="IPv4 CIDR block for the private subnet in the primary AZ. "
+                    "[Possibly not modifiable after stack creation]",
+        Type="String",
+        Default="10.0.8.0/22",
+        AllowedPattern=PRIVATE_IPV4_CIDR_REGEX,
+        ConstraintDescription=PRIVATE_IPV4_CONSTRAINT,
+    ),
+    group="Global",
+    label="Private Subnet A CIDR Block",
+)
+
+private_subnet_b_cidr = template.add_parameter(
+    Parameter(
+        "PrivateSubnetBCidr",
+        Description="IPv4 CIDR block for the private subnet in the secondary AZ. "
+                    "[Possibly not modifiable after stack creation]",
+        Type="String",
+        Default="10.0.12.0/22",
+        AllowedPattern=PRIVATE_IPV4_CIDR_REGEX,
+        ConstraintDescription=PRIVATE_IPV4_CONSTRAINT,
+    ),
+    group="Global",
+    label="Private Subnet B CIDR Block",
+)
+
+
 vpc = VPC(
     "Vpc",
     template=template,
-    CidrBlock=vpc_cidr,
+    CidrBlock=Ref(vpc_cidr),
     EnableDnsSupport=True,
     EnableDnsHostnames=True,
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "vpc"]),
+    ),
 )
 
 
 # Allow outgoing to outside VPC
-internet_gateway = InternetGateway("InternetGateway", template=template)
+internet_gateway = InternetGateway(
+    "InternetGateway",
+    template=template,
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "igw"]),
+    ),
+)
 
 
 # Attach Gateway to VPC
@@ -63,7 +147,15 @@ VPCGatewayAttachment(
 
 
 # Public route table
-public_route_table = RouteTable("PublicRouteTable", template=template, VpcId=Ref(vpc))
+public_route_table = RouteTable(
+    "PublicRouteTable",
+    template=template,
+    VpcId=Ref(vpc),
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "public"]),
+    ),
+)
+
 
 public_route = Route(
     "PublicRoute",
@@ -74,91 +166,115 @@ public_route = Route(
 )
 
 
-# Holds public instances & elastic load balancers
-public_a_subnet_cidr = "10.1.0.0/24"
-public_a_subnet = Subnet(
-    "PublicASubnet",
+# Holds load balancer, NAT gateway, and bastion (if specified)
+public_subnet_a = Subnet(
+    "PublicSubnetA",
     template=template,
     VpcId=Ref(vpc),
-    CidrBlock=public_a_subnet_cidr,
+    CidrBlock=Ref(public_subnet_a_cidr),
     MapPublicIpOnLaunch=True,  # required when routing through an InternetGateway
     AvailabilityZone=Ref(primary_az),
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "public-a"]),
+    ),
 )
 
 SubnetRouteTableAssociation(
-    "PublicASubnetRouteTableAssociation",
+    "PublicSubnetARouteTableAssociation",
     template=template,
     RouteTableId=Ref(public_route_table),
-    SubnetId=Ref(public_a_subnet),
+    SubnetId=Ref(public_subnet_a),
 )
 
-public_b_subnet_cidr = "10.1.1.0/24"
-public_b_subnet = Subnet(
-    "PublicBSubnet",
+public_subnet_b = Subnet(
+    "PublicSubnetB",
     template=template,
     VpcId=Ref(vpc),
-    CidrBlock=public_b_subnet_cidr,
+    CidrBlock=Ref(public_subnet_b_cidr),
     MapPublicIpOnLaunch=True,  # required when routing through an InternetGateway
     AvailabilityZone=Ref(secondary_az),
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "public-b"]),
+    ),
 )
 
 SubnetRouteTableAssociation(
-    "PublicBSubnetRouteTableAssociation",
+    "PublicSubnetBRouteTableAssociation",
     template=template,
     RouteTableId=Ref(public_route_table),
-    SubnetId=Ref(public_b_subnet),
+    SubnetId=Ref(public_subnet_b),
 )
 
 
-# Private route table
 if USE_NAT_GATEWAY:
     # NAT
-    nat_ip = EIP("NatIp", template=template, Domain="vpc")
+    nat_ip = EIP(
+        "NatIp",
+        template=template,
+        Domain="vpc",
+    )
+
     nat_gateway = NatGateway(
         "NatGateway",
         template=template,
         AllocationId=GetAtt(nat_ip, "AllocationId"),
-        SubnetId=Ref(public_a_subnet),
+        SubnetId=Ref(public_subnet_a),
+        Tags=Tags(
+            Name=Join("-", [Ref("AWS::StackName"), "nat"]),
+        ),
     )
 else:
     nat_gateway = None
 
+
 # Note: private route is added to this table in networking.py (after we know the NAT instance ID)
-private_route_table = RouteTable("PrivateRouteTable", template=template, VpcId=Ref(vpc))
-
-
-# Holds backends instances
-private_a_subnet_cidr = "10.1.2.0/24"
-private_a_subnet = Subnet(
-    "PrivateASubnet",
+private_route_table = RouteTable(
+    "PrivateRouteTable",
     template=template,
     VpcId=Ref(vpc),
-    CidrBlock=private_a_subnet_cidr,
-    MapPublicIpOnLaunch=False,
-    AvailabilityZone=Ref(primary_az),
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "private"]),
+    ),
 )
 
-SubnetRouteTableAssociation(
-    "PrivateARouteTableAssociation",
+# Holds backend instances
+private_subnet_a = Subnet(
+    "PrivateSubnetA",
     template=template,
-    SubnetId=Ref(private_a_subnet),
+    VpcId=Ref(vpc),
+    CidrBlock=Ref(private_subnet_a_cidr),
+    MapPublicIpOnLaunch=False,
+    AvailabilityZone=Ref(primary_az),
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "private-a"]),
+    ),
+)
+
+
+SubnetRouteTableAssociation(
+    "PrivateSubnetARouteTableAssociation",
+    template=template,
+    SubnetId=Ref(private_subnet_a),
     RouteTableId=Ref(private_route_table),
 )
 
 
-private_b_subnet_cidr = "10.1.3.0/24"
-private_b_subnet = Subnet(
-    "PrivateBSubnet",
+private_subnet_b = Subnet(
+    "PrivateSubnetB",
     template=template,
     VpcId=Ref(vpc),
-    CidrBlock=private_b_subnet_cidr,
+    CidrBlock=Ref(private_subnet_b_cidr),
     MapPublicIpOnLaunch=False,
     AvailabilityZone=Ref(secondary_az),
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "private-b"]),
+    ),
 )
 
+
 SubnetRouteTableAssociation(
-    "PrivateBRouteTableAssociation",
+    "PrivateSubnetBRouteTableAssociation",
     template=template,
-    SubnetId=Ref(private_b_subnet),
+    SubnetId=Ref(private_subnet_b),
     RouteTableId=Ref(private_route_table),
 )

--- a/vpc-template/stack/vpc.py
+++ b/vpc-template/stack/vpc.py
@@ -1,0 +1,164 @@
+import os
+
+from troposphere import GetAtt, Parameter, Ref
+from troposphere.ec2 import (
+    EIP,
+    VPC,
+    InternetGateway,
+    NatGateway,
+    Route,
+    RouteTable,
+    Subnet,
+    SubnetRouteTableAssociation,
+    VPCGatewayAttachment,
+)
+
+from .template import template
+
+USE_NAT_GATEWAY = os.environ.get("USE_NAT_GATEWAY") == "on"
+
+primary_az = template.add_parameter(
+    Parameter(
+        "PrimaryAZ",
+        Description="The primary availability zone for creating resources.",
+        Type="AWS::EC2::AvailabilityZone::Name",
+    ),
+    group="Global",
+    label="Primary Availability Zone",
+)
+
+
+secondary_az = template.add_parameter(
+    Parameter(
+        "SecondaryAZ",
+        Description="The secondary availability zone for creating resources. Must differ from primary zone.",
+        Type="AWS::EC2::AvailabilityZone::Name",
+    ),
+    group="Global",
+    label="Secondary Availability Zone",
+)
+
+
+vpc_cidr = "10.1.0.0/22"
+vpc = VPC(
+    "Vpc",
+    template=template,
+    CidrBlock=vpc_cidr,
+    EnableDnsSupport=True,
+    EnableDnsHostnames=True,
+)
+
+
+# Allow outgoing to outside VPC
+internet_gateway = InternetGateway("InternetGateway", template=template)
+
+
+# Attach Gateway to VPC
+VPCGatewayAttachment(
+    "GatewayAttachement",
+    template=template,
+    VpcId=Ref(vpc),
+    InternetGatewayId=Ref(internet_gateway),
+)
+
+
+# Public route table
+public_route_table = RouteTable("PublicRouteTable", template=template, VpcId=Ref(vpc))
+
+public_route = Route(
+    "PublicRoute",
+    template=template,
+    GatewayId=Ref(internet_gateway),
+    DestinationCidrBlock="0.0.0.0/0",
+    RouteTableId=Ref(public_route_table),
+)
+
+
+# Holds public instances & elastic load balancers
+public_a_subnet_cidr = "10.1.0.0/24"
+public_a_subnet = Subnet(
+    "PublicASubnet",
+    template=template,
+    VpcId=Ref(vpc),
+    CidrBlock=public_a_subnet_cidr,
+    MapPublicIpOnLaunch=True,  # required when routing through an InternetGateway
+    AvailabilityZone=Ref(primary_az),
+)
+
+SubnetRouteTableAssociation(
+    "PublicASubnetRouteTableAssociation",
+    template=template,
+    RouteTableId=Ref(public_route_table),
+    SubnetId=Ref(public_a_subnet),
+)
+
+public_b_subnet_cidr = "10.1.1.0/24"
+public_b_subnet = Subnet(
+    "PublicBSubnet",
+    template=template,
+    VpcId=Ref(vpc),
+    CidrBlock=public_b_subnet_cidr,
+    MapPublicIpOnLaunch=True,  # required when routing through an InternetGateway
+    AvailabilityZone=Ref(secondary_az),
+)
+
+SubnetRouteTableAssociation(
+    "PublicBSubnetRouteTableAssociation",
+    template=template,
+    RouteTableId=Ref(public_route_table),
+    SubnetId=Ref(public_b_subnet),
+)
+
+
+# Private route table
+if USE_NAT_GATEWAY:
+    # NAT
+    nat_ip = EIP("NatIp", template=template, Domain="vpc")
+    nat_gateway = NatGateway(
+        "NatGateway",
+        template=template,
+        AllocationId=GetAtt(nat_ip, "AllocationId"),
+        SubnetId=Ref(public_a_subnet),
+    )
+else:
+    nat_gateway = None
+
+# Note: private route is added to this table in networking.py (after we know the NAT instance ID)
+private_route_table = RouteTable("PrivateRouteTable", template=template, VpcId=Ref(vpc))
+
+
+# Holds backends instances
+private_a_subnet_cidr = "10.1.2.0/24"
+private_a_subnet = Subnet(
+    "PrivateASubnet",
+    template=template,
+    VpcId=Ref(vpc),
+    CidrBlock=private_a_subnet_cidr,
+    MapPublicIpOnLaunch=False,
+    AvailabilityZone=Ref(primary_az),
+)
+
+SubnetRouteTableAssociation(
+    "PrivateARouteTableAssociation",
+    template=template,
+    SubnetId=Ref(private_a_subnet),
+    RouteTableId=Ref(private_route_table),
+)
+
+
+private_b_subnet_cidr = "10.1.3.0/24"
+private_b_subnet = Subnet(
+    "PrivateBSubnet",
+    template=template,
+    VpcId=Ref(vpc),
+    CidrBlock=private_b_subnet_cidr,
+    MapPublicIpOnLaunch=False,
+    AvailabilityZone=Ref(secondary_az),
+)
+
+SubnetRouteTableAssociation(
+    "PrivateBRouteTableAssociation",
+    template=template,
+    SubnetId=Ref(private_b_subnet),
+    RouteTableId=Ref(private_route_table),
+)

--- a/vpc-template/stack/vpc.py
+++ b/vpc-template/stack/vpc.py
@@ -1,6 +1,6 @@
 import os
 
-from troposphere import GetAtt, Join, Ref, Tags
+from troposphere import GetAtt, Join, Ref, Sub, Tags
 from troposphere.ec2 import (
     EIP,
     VPC,
@@ -10,6 +10,7 @@ from troposphere.ec2 import (
     RouteTable,
     Subnet,
     SubnetRouteTableAssociation,
+    VPCEndpoint,
     VPCGatewayAttachment,
 )
 
@@ -277,4 +278,13 @@ SubnetRouteTableAssociation(
     template=template,
     SubnetId=Ref(private_subnet_b),
     RouteTableId=Ref(private_route_table),
+)
+
+
+VPCEndpoint(
+    "VPCS3Endpoint",
+    template=template,
+    ServiceName=Sub("com.amazonaws.${AWS::Region}.s3"),
+    VpcId=Ref(vpc),
+    RouteTableIds=[Ref(private_route_table)],
 )


### PR DESCRIPTION
This should (eventually) create all resources required by fabulaws, except for the instances themselves (which are created by fabulaws). See: https://fabulaws.readthedocs.io/en/latest/initial-setup.html#aws-configuration

I.e., the goal is to avoid having to manually create those resources AND avoid having to distributed IAM secrets to the instances.

To do:

- [x] ELB logging to S3 buckets
- [x] AG scaling rules (via stack parameters?)
- [x] notifications of autoscaling actions to email
- [ ] ~CloudWatch monitoring rules?~ They aren't very generic..keep them manual for now.