### PR TITLE
switch to using python3 on the server side (still python2 locally)

### DIFF
--- a/fabulaws/api.py
+++ b/fabulaws/api.py
@@ -43,8 +43,8 @@ def call_python(method, *args):
     """
     module = '.'.join(method.split('.')[:-1])
     args = json.dumps(args)[1:-1]
-    output = run('/usr/bin/env python -c \'import json, {module};'
-                 'print json.dumps({method}({args}))\''
+    output = run('/usr/bin/env python3 -c \'import json, {module};'
+                 'print(json.dumps({method}({args})))\''
                  ''.format(module=module, method=method, args=args))
     return json.loads(output)
 

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1741,7 +1741,7 @@ def install_awslogs():
         sudo('curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O', user=env.deploy_user)
         # This script only supports Python 2.6 - 3.5, so make sure Python 2.7 is installed (any Python 3 version is likely too new)
         sudo('apt-get install -y python2.7')
-        sudo('python2 awslogs-agent-setup.py --region us-east-1 --non-interactive --configfile awslogs.conf')
+        sudo('python2.7 awslogs-agent-setup.py --region us-east-1 --non-interactive --configfile awslogs.conf')
         sudo('rm awslogs.conf')
     # upload AWS credentials
     template = os.path.join(env.templates_dir, 'awslogs', 'aws.conf')

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -832,7 +832,7 @@ def create_virtualenv():
     """ setup virtualenv on remote host """
 
     require('virtualenv_root', provided_by=env.environments)
-    cmd = ['virtualenv', '--clear', '--distribute',
+    cmd = ['virtualenv', '--clear',
            '--python=%(python)s' % env, env.virtualenv_root]
     sudo(' '.join(cmd), user=env.deploy_user)
 
@@ -1737,8 +1737,11 @@ def install_awslogs():
     destination = '/etc/init/awslogs.service'
     _upload_template(template, destination, user='root', context=context)
     with(cd('/tmp')):
+        # FIXME: Switch to new (.deb based) CloudWatch agent (ensuring that it picks up all the same log files!)
         sudo('curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O', user=env.deploy_user)
-        sudo('python awslogs-agent-setup.py --region us-east-1 --non-interactive --configfile awslogs.conf')
+        # This script only supports Python 2.6 - 3.5, so make sure Python 2.7 is installed (any Python 3 version is likely too new)
+        sudo('apt-get install -y python2.7')
+        sudo('python2 awslogs-agent-setup.py --region us-east-1 --non-interactive --configfile awslogs.conf')
         sudo('rm awslogs.conf')
     # upload AWS credentials
     template = os.path.join(env.templates_dir, 'awslogs', 'aws.conf')

--- a/fabulaws/library/wsgiautoscale/servers.py
+++ b/fabulaws/library/wsgiautoscale/servers.py
@@ -110,7 +110,7 @@ class BaseInstance(FirewallMixin, UbuntuInstance):
             self._add_swap('/dev/mapper/{0}'.format(crypt_name))
         if swap_mb > 0:
             if not files.exists(self.default_swap_file):
-                sudo('dd if=/dev/zero of={0} bs=1M count={1}'.format(self.default_swap_file, swap_mb))
+                sudo('fallocate -l {0}M {1}'.format(swap_mb, self.default_swap_file))
                 sudo('chown root:root {0}'.format(self.default_swap_file))
                 sudo('chmod 600 {0}'.format(self.default_swap_file))
                 self._add_swap(self.default_swap_file)
@@ -277,10 +277,6 @@ class AppMixin(PythonMixin):
     Mixin that installs the Python application dependencies, including the appropriate
     versions of Python, PIP, and virtualenv.
     """
-
-    python_packages = ['python2.7', 'python2.7-dev']
-    python_pip_version = '9.0.3'
-    python_virtualenv_version = '15.2.0'
 
     @uses_fabric
     def install_less_and_yuglify(self):

--- a/fabulaws/library/wsgiautoscale/templates/stunnel.conf
+++ b/fabulaws/library/wsgiautoscale/templates/stunnel.conf
@@ -8,7 +8,7 @@
 foreground = yes
 
 ; Protocol version (all, SSLv2, SSLv3, TLSv1)
-sslVersion = TLSv1
+sslVersion = all
 
 ; We are not running as root; disable the chroot
 ;chroot = /var/lib/stunnel4/

--- a/fabulaws/ubuntu/instances/base.py
+++ b/fabulaws/ubuntu/instances/base.py
@@ -87,7 +87,7 @@ class UbuntuInstance(BaseAptMixin, EC2Instance):
         """
         if not passwd:
             passwd = getpass.getpass('Enter LUKS passphrase for cryptsetup: ')
-        self.install_packages(['python-pexpect', 'cryptsetup'])
+        self.install_packages(['python3-pexpect', 'cryptsetup'])
         crypt = 'crypt-{0}'.format(device.split('/')[-1])
         with hide('stdout'):
             answers = [

--- a/fabulaws/ubuntu/packages/postgres.py
+++ b/fabulaws/ubuntu/packages/postgres.py
@@ -84,7 +84,7 @@ class PostgresMixin(AptMixin):
     @uses_fabric
     def pg_version(self):
         version = run('pg_config --version')
-        return re.findall(r'(\d+\.\d+)\.?\d+?', version)[0]
+        return re.findall(r'(\d+\.\d+)\.?', version)[0]
 
     @cached_property()
     @uses_fabric

--- a/fabulaws/ubuntu/packages/python.py
+++ b/fabulaws/ubuntu/packages/python.py
@@ -1,9 +1,4 @@
-import copy
-import random
-import urllib2
-
-from fabric.api import *
-from fabric.contrib import files
+from fabric.api import sudo
 
 from fabulaws.decorators import uses_fabric
 from fabulaws.ubuntu.packages.base import AptMixin
@@ -16,10 +11,9 @@ class PythonMixin(AptMixin):
 
     package_name = 'python'
     python_ppa = None
-    python_packages = ['python', 'python-dev']
+    python_packages = ['python3', 'python3-dev']
     python_install_tools = True
-    python_pip_version = None # install the latest version
-    python_virtualenv_version = None # install the latest version
+    python_virtualenv_version = None  # install the latest version
 
     @uses_fabric
     def install_python_tools(self):
@@ -27,15 +21,12 @@ class PythonMixin(AptMixin):
         Installs the required Python tools from PyPI.
         """
 
-        mirror = 'https://pypi.python.org'
-        version = ''
-        if self.python_pip_version:
-            version = '==%s' % self.python_pip_version
-        sudo("easy_install -i %s/simple/ -U pip%s" % (mirror, version))
+        sudo('curl https://bootstrap.pypa.io/get-pip.py --output /tmp/get-pip.py')
+        sudo("python3 /tmp/get-pip.py")
         version = ''
         if self.python_virtualenv_version:
             version = '==%s' % self.python_virtualenv_version
-        sudo("pip install -i %s/simple/ -U virtualenv%s" % (mirror, version))
+        sudo("pip install -U virtualenv%s" % version)
 
     def setup(self):
         """
@@ -44,5 +35,4 @@ class PythonMixin(AptMixin):
         """
         super(PythonMixin, self).setup()
         if self.python_install_tools:
-            self.install_packages(['python-setuptools'])
             self.install_python_tools()


### PR DESCRIPTION
Updates the server-side commands to work on Ubuntu 20.04 with Python 3.8.

This still uses Python 2 locally, but I see a Python 3 upgrade is in process already on the `python3` branch.

To do:
- [x] Turn of protected mode in redis