### PR TITLE
Apply a few remaining python 3 fixes

### DIFF
--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import sys
 import time

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -709,7 +709,7 @@ def upload_supervisor_conf(run_update=True):
         sudo('rm /etc/supervisor/conf.d/%(project)s-*.conf' % env)
     sudo('ln -s /%(home)s/services/supervisor/%(environment)s.conf /etc/supervisor/conf.d/%(project)s-%(environment)s.conf' % env)
     if run_update:
-        sudo(u'supervisorctl update')
+        sudo('supervisorctl update')
 
 
 @task
@@ -1056,7 +1056,7 @@ def supervisor(command, group, process=None):
         command = '%(supervisor_command)s %(environment)s-%(supervisor_group)s:%(environment)s-%(supervisor_process)s' % env
     else:
         command = '%(supervisor_command)s %(environment)s-%(supervisor_group)s:*' % env
-    sudo(u'supervisorctl %s' % command)
+    sudo('supervisorctl %s' % command)
 
 
 @task

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1562,7 +1562,7 @@ def deploy_serial_without_autoscaling(deployment_tag, environment, wait=30):
     initial_states = dict([((server.instance.id, elb_name), server.elb_state(elb_name))
                            for server in servers for elb_name in env.elb_names])
     # make sure we have at least two servers in service in the load balancer(s)
-    assert initial_states.values().count('InService') >= 2*len(env.elb_names), \
+    assert list(initial_states.values()).count('InService') >= 2*len(env.elb_names), \
            'Need 2 or more instances per load balancer in service to run deploy_serial_without_autoscaling'
     executel('deploy_worker')
     for server in servers:

--- a/fabulaws/library/wsgiautoscale/servers.py
+++ b/fabulaws/library/wsgiautoscale/servers.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import os
 import time
 import subprocess

--- a/fabulaws/ubuntu/packages/base.py
+++ b/fabulaws/ubuntu/packages/base.py
@@ -20,7 +20,7 @@ class BaseAptMixin(object):
     def install_packages(self, packages):
         """Install apt packages from a list."""
 
-        sudo(u"apt-get -qq -y install %s" % u" ".join(packages))
+        sudo("apt-get -qq -y install %s" % " ".join(packages))
 
     @uses_fabric
     def install_packages_from_file(self, file_name):
@@ -32,7 +32,7 @@ class BaseAptMixin(object):
     def update_apt_sources(self):
         """Update apt source."""
         with settings(warn_only=True):
-            sudo(u"apt-get -qq update || apt-get -qq update")
+            sudo("apt-get -qq update || apt-get -qq update")
 
     @uses_fabric
     def upgrade_packages(self):
@@ -41,7 +41,7 @@ class BaseAptMixin(object):
         self.update_apt_sources()
         # make sure apt/dpkg keep our installed config files, if any, and don't
         # prompt for user input:
-        sudo(u'export DEBIAN_FRONTEND=noninteractive ; apt-get dist-upgrade -y '
+        sudo('export DEBIAN_FRONTEND=noninteractive ; apt-get dist-upgrade -y '
              '-o Dpkg::Options::="--force-confdef" '
              '-o Dpkg::Options::="--force-confold" --force-yes')
 
@@ -50,9 +50,9 @@ class BaseAptMixin(object):
         """Add personal package archive."""
 
         if self.ubuntu_release >= Decimal('12.04'):
-            sudo(u"apt-add-repository -y %s" % name)
+            sudo("apt-add-repository -y %s" % name)
         else:
-            sudo(u"apt-add-repository %s" % name)
+            sudo("apt-add-repository %s" % name)
         self.update_apt_sources()
 
     @uses_fabric

--- a/fabulaws/ubuntu/packages/memcached.py
+++ b/fabulaws/ubuntu/packages/memcached.py
@@ -32,7 +32,7 @@ class MemcachedMixin(AptMixin):
 
     @uses_fabric
     def memcached_configure(self, **kwargs):
-        for key, (opt, pat) in self.memcached_conf_patterns.iteritems():
+        for key, (opt, pat) in self.memcached_conf_patterns.items():
             if key in kwargs:
                 val = kwargs[key]
             else:

--- a/fabulaws/ubuntu/packages/postgres.py
+++ b/fabulaws/ubuntu/packages/postgres.py
@@ -299,12 +299,12 @@ class PostgresMixin(AptMixin):
         self.sql("ALTER USER %s WITH PASSWORD '%s'" % (username, password))
 
     @uses_fabric
-    def create_db(self, name, owner=None, encoding=u'UTF-8'):
+    def create_db(self, name, owner=None, encoding='UTF-8'):
         """Create a Postgres database."""
 
-        flags = u''
+        flags = ''
         if encoding:
-            flags = u'-E %s' % encoding
+            flags = '-E %s' % encoding
         if owner:
-            flags = u'%s -O %s' % (flags, owner)
+            flags = '%s -O %s' % (flags, owner)
         sudo('createdb %s %s' % (flags, name), user='postgres')

--- a/fabulaws/ubuntu/packages/rabbitmq.py
+++ b/fabulaws/ubuntu/packages/rabbitmq.py
@@ -46,22 +46,22 @@ class RabbitMqMixin(AptMixin):
     def rabbitmq_command(self, command):
         """Run a rabbitmqctl command."""
 
-        sudo(u'rabbitmqctl %s' % command)
+        sudo('rabbitmqctl %s' % command)
 
     def create_mq_user(self, username, password):
         """Create a rabbitmq user."""
 
-        self.rabbitmq_command(u'add_user %s %s' % (username, password))
+        self.rabbitmq_command('add_user %s %s' % (username, password))
 
     def create_mq_vhost(self, name):
         """Create a rabbitmq vhost."""
 
-        self.rabbitmq_command(u'add_vhost %s' % name)
+        self.rabbitmq_command('add_vhost %s' % name)
 
     def set_mq_vhost_permissions(self, vhost, username, permissions='".*" ".*" ".*"'):
         """Set permssions for a user on a given vhost."""
 
-        self.rabbitmq_command(u'set_permissions -p %s %s %s' % (vhost, username, permissions))
+        self.rabbitmq_command('set_permissions -p %s %s %s' % (vhost, username, permissions))
 
     @uses_fabric
     def rabbitmq_configure(self):


### PR DESCRIPTION
Commentary:

1. This was prompted by discovering one remaining instance of `iteritems()`
2. The `u""` and `__future__` removals are optional but we might as well do them
3. I looked through the output of `2to3 -w -f print` and didn't see anything I wanted to change (I believe all our print statements conform already)
4. I looked through the output of `2to3 -w -f dict` (after fixing `iteritems()`) and **all but one** of the `list()` wrappers looked unnecessary. A second set of eyes for any bugs that might be hiding due to not fully applying this fix would be helpful.


Test: `2to3 -w -x print -x dict fabulaws` should end up with no changes (plus a brief look at 4 above).
