### PR TITLE
add entrypoint shell script for gunicorn so we know pgbouncer is up before starting gunicorn

### DIFF
--- a/fabulaws/library/wsgiautoscale/templates/gunicorn-entrypoint.sh
+++ b/fabulaws/library/wsgiautoscale/templates/gunicorn-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+until psql $DATABASE_URL -c '\l'; do
+    >&2 echo "Postgres is unavailable - sleeping"
+    sleep 1
+done
+
+>&2 echo "Postgres is up - continuing"
+
+exec "$@"

--- a/fabulaws/library/wsgiautoscale/templates/supervisor.conf
+++ b/fabulaws/library/wsgiautoscale/templates/supervisor.conf
@@ -1,14 +1,15 @@
 {% if current_role == 'web' %}
 [program:{{ environment }}-server]
 process_name=%(program_name)s
-command={{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class={{ worker_class }} {{ wsgi_app }} --timeout={{ timeout }}
+command={{ gunicorn_entrypoint }} {{ virtualenv_root }}/bin/newrelic-admin run-program {{ virtualenv_root }}/bin/gunicorn --bind="127.0.0.1:{{ server_port }}" --workers={{ worker_count }} --worker-class={{ worker_class }} {{ wsgi_app }} --timeout={{ timeout }}
 directory={{ code_root }}
 user={{ webserver_user }}
 autostart=true
 autorestart=true
 stdout_logfile={{ log_dir }}/gunicorn.log
 redirect_stderr=true
-environment=NEW_RELIC_CONFIG_FILE='{{ services }}/newrelic-{{ environment }}-web.ini',DJANGO_SETTINGS_MODULE={{ settings_managepy }}
+; IMPORTANT: As of 8/2020, DATABASE_URL is used only by gunicorn-entrypoint.sh, not by Django itself, as Django requires a primary plus N (usually 0-2) replicas
+environment=NEW_RELIC_CONFIG_FILE='{{ services }}/newrelic-{{ environment }}-web.ini',DJANGO_SETTINGS_MODULE={{ settings_managepy }},DATABASE_URL='postgres://{{ database_user }}:{{ database_password }}@localhost/{{ master_database.database_local_name }}'
 
 [group:{{ environment }}-web]
 programs={{ environment }}-server


### PR DESCRIPTION
On any web server:
```
$ sudo supervisorctl stop all
testing-pgbouncer:testing-stunnel: stopped
testing-pgbouncer: stopped
testing-web:testing-server: stopped
$ sudo supervisorctl start testing-web:*
testing-web:testing-server: started
$ sudo supervisorctl start all
testing-pgbouncer:testing-stunnel: started
testing-pgbouncer: started
$ tail -n 100 /home/foo/www/testing/log/gunicorn.log
<snip>
[2020-08-18 19:49:36 +0000] [3732] [INFO] Shutting down: Master
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
psql: error: could not connect to server: could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
Postgres is unavailable - sleeping
                               List of databases
    Name     |  Owner   | Encoding | Collate |  Ctype  |   Access privileges   
-------------+----------+----------+---------+---------+-----------------------
 postgres    | postgres | UTF8     | C.UTF-8 | C.UTF-8 | 
 foo_testing | foo      | UTF8     | C.UTF-8 | C.UTF-8 | 
 template0   | postgres | UTF8     | C.UTF-8 | C.UTF-8 | =c/postgres          +
             |          |          |         |         | postgres=CTc/postgres
 template1   | postgres | UTF8     | C.UTF-8 | C.UTF-8 | =c/postgres          +
             |          |          |         |         | postgres=CTc/postgres
(4 rows)

Postgres is up - continuing
[2020-08-18 19:49:56 +0000] [3779] [INFO] Starting gunicorn 20.0.4
[2020-08-18 19:49:56 +0000] [3779] [INFO] Listening at: http://127.0.0.1:8000 (3779)
[2020-08-18 19:49:56 +0000] [3779] [INFO] Using worker: sync
[2020-08-18 19:49:56 +0000] [3898] [INFO] Booting worker with pid: 3898
[2020-08-18 19:49:56 +0000] [3899] [INFO] Booting worker with pid: 3899
[2020-08-18 19:49:56 +0000] [3900] [INFO] Booting worker with pid: 3900
[2020-08-18 19:49:56 +0000] [3901] [INFO] Booting worker with pid: 3901
```