### PR TITLE
Optionally Run PostBootstrap

### DIFF
--- a/docs/useful_commands.rst
+++ b/docs/useful_commands.rst
@@ -103,7 +103,10 @@ Databases
 ---------
 
 * ``fab environment upload_pgbouncer_conf``
-* ``fab reload_production_db[:prod_env[,src_env]]``
+* ``fab reload_production_db[:prod_env[,src_env]]`` - Note: If you would like FabulAWS
+  to also run some tasks after its ``reload_production_db`` task, define a
+  ``post_reload_production_db`` task in your fabfile.py, and FabulAWS will
+  automatically run it after running its ``reload_production_db`` task.
 * ``fab reset_local_db:dbname``
 * ``fab environment reset_slaves`` - this resets the config & data on the db slaves and is a good
   way to get things back into a working state if the replication seems broken

--- a/docs/useful_commands.rst
+++ b/docs/useful_commands.rst
@@ -52,7 +52,11 @@ Misc
 EC2 instances
 -------------
 
-* ``fab new:deployment,environment,role[,avail_zone[,count]]``
+* ``fab new:deployment,environment,role[,avail_zone[,count]]`` - set up a new EC2 instance,
+  including installing a number of things. Note: FabulAWS runs a ``bootstrap`` task as a
+  part of ``new``. If you would like FabulAWS to also run some tasks after its ``bootstrap``
+  task, define a ``post_bootstrap`` task in your fabfile.py, and FabulAWS will
+  automatically run it after running its ``bootstrap`` task.
 
 Handling secrets
 ----------------

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1453,6 +1453,11 @@ def reload_production_db(prod_env=env.default_deployment, src_env="production"):
     executel("end_upgrade")
     executel("resume_autoscaling_processes", env.deployment_tag, env.environment)
 
+    # Run a "post_reload_production_db" task, if it's defined.
+    available_commands = list_commands("", "short")
+    if "post_reload_production_db" in available_commands:
+        executel("post_reload_production_db")
+
 
 @task
 @roles("db-primary")

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -37,6 +37,7 @@ from fabric.api import (
 from fabric.colors import red
 from fabric.contrib.files import append, exists, sed, uncomment, upload_template
 from fabric.exceptions import NetworkError
+from fabric.main import list_commands
 from fabric.network import disconnect_all
 
 from fabulaws.api import answer_sudo, ec2_instances, sshagent_run
@@ -584,6 +585,10 @@ def _new(
             executel("install_awslogs", hosts=env.roledefs[role])
         if role in ("worker", "web"):
             executel("bootstrap", hosts=env.roledefs[role])
+            # Run a "post_bootstrap" task, if it's defined.
+            available_commands = list_commands("", "short")
+            if "post_bootstrap" in available_commands:
+                executel("post_bootstrap")
     except:  # noqa: E722
         logger.exception(
             "server post-setup failed. tags=%s; terminate_on_failure=%s.",

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1935,6 +1935,11 @@ def install_munin():
 @task
 @parallel
 def install_rsyslog():
+    # Run a "pre_install_rsyslog" task, if it's defined.
+    available_commands = list_commands("", "short")
+    if "pre_install_rsyslog" in available_commands:
+        executel("pre_install_rsyslog")
+
     require("environment", provided_by=env.environments)
     context = dict(env)
     context["current_role"] = _current_roles()[0]

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -585,10 +585,6 @@ def _new(
             executel("install_awslogs", hosts=env.roledefs[role])
         if role in ("worker", "web"):
             executel("bootstrap", hosts=env.roledefs[role])
-            # Run a "post_bootstrap" task, if it's defined.
-            available_commands = list_commands("", "short")
-            if "post_bootstrap" in available_commands:
-                executel("post_bootstrap")
     except:  # noqa: E722
         logger.exception(
             "server post-setup failed. tags=%s; terminate_on_failure=%s.",
@@ -1072,6 +1068,11 @@ def bootstrap(purge=False):
     update_services()
     create_virtualenv()
     update_requirements()
+
+    # Run a "post_bootstrap" task, if it's defined.
+    available_commands = list_commands("", "short")
+    if "post_bootstrap" in available_commands:
+        executel("post_bootstrap")
 
 
 # CODE DEPLOYMENT


### PR DESCRIPTION
After running the `bootstrap` task in `_new_`, a `post_bootstrap` task can now be run, if it is defined (presumably in a project's `fabfile.py`). If `post_bootstrap` is not defined, then fabulaws' behavior does not change from before.