### PR TITLE
Limit user skipping to files that end in .gecos

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+* v1.0.?, ???
+
+  * Fix bug where users with periods in their usernames were ignored
+
 * v1.0.7, August 27, 2020
 
   * Fix bug introduced in 1.0.6 with pre/post tasks running on more hosts than intended

--- a/fabulaws/library/wsgiautoscale/servers.py
+++ b/fabulaws/library/wsgiautoscale/servers.py
@@ -68,8 +68,8 @@ class BaseInstance(FirewallMixin, UbuntuInstance):
         users = [
             (n, os.path.join(users_dir, n))
             for n in os.listdir(users_dir)
-            if "." not in n
-        ]  # skip files ending in '.gecos' or other suffixes
+            if not n.endswith(".gecos")
+        ]  # skip files ending in '.gecos'
         return users
 
     def _add_swap(self, path):


### PR DESCRIPTION
This allows a user to have a "." in their username where previously they would be skipped entirely.