### PR TITLE
Fix dbrestore's failure to delete secret key (permission denied)

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release History
 * v1.0.?, ???
 
   * Fix bug where users with periods in their usernames were ignored
+  * Pass ``--yes`` to ``gpg`` to auto-confirm removal of private key from key ring during dbrestore process
 
 * v1.0.7, August 27, 2020
 

--- a/fabulaws/library/wsgiautoscale/api.py
+++ b/fabulaws/library/wsgiautoscale/api.py
@@ -1215,7 +1215,7 @@ def dbrestore(filepath):
         put(private_key, dest)
         with settings(warn_only=True):
             sudo(
-                'gpg --homedir {0} --batch --delete-secret-keys "{1}"'.format(
+                'gpg --homedir {0} --batch --yes --delete-secret-keys "{1}"'.format(
                     env.gpg_dir, env.backup_key_fingerprint
                 ),
                 user=env.webserver_user,
@@ -1248,7 +1248,7 @@ def dbrestore(filepath):
     finally:
         with settings(warn_only=True):
             sudo(
-                'gpg --homedir {0} --batch --delete-secret-keys "{1}"'.format(
+                'gpg --homedir {0} --batch --yes --delete-secret-keys "{1}"'.format(
                     env.gpg_dir, env.backup_key_fingerprint
                 ),
                 user=env.webserver_user,


### PR DESCRIPTION
``dbrestore`` currently fails to delete the GPG secret key from the keyring, which is used to decrypt database backups during the restore process:

```sh
# ...
sudo: gpg --batch --delete-secret-keys # ...
out: gpg: deleting secret key failed: Permission denied
out: gpg: deleting secret subkey failed: Permission denied
gpg: ***SNIP***: delete key failed: Permission denied
# ...
```

Using ``gpg --debug-level guru`` revealed a message regarding pinentry:

```sh
$ gpg --debug-level guru # ...
# ...
gpg: DBG: chan_5 -> SETKEYDESC Do+you+really+want+to+permanently+delete+the+OpenPGP+secret+key***SNIP***
gpg: DBG: chan_5 <- OK
gpg: DBG: chan_5 -> DELETE_KEY ***SNIP***
gpg: DBG: chan_5 <- INQUIRE PINENTRY_LAUNCHED 479021 curses 1.1.0 /dev/pts/0 xterm-256color -
gpg: pinentry launched (479021 curses 1.1.0 /dev/pts/0 xterm-256color -)
gpg: DBG: chan_5 -> END
gpg: DBG: chan_5 <- ERR 83918849 Permission denied <Pinentry>
# ...
```

``gpg`` was requesting a delete confirmation and reading the man page revealed ``--yes`` can be used to skip this:

```sh
    --delete-secret-keys name
            Remove key from the secret keyring. In batch mode the key must be specified by fingerprint.
            The option --yes can be used to advice gpg-agent not to request a confirmation...
```

This PR just adds the ``--yes`` flag to the ``--delete-secret-keys`` commands.
