### PR TITLE
Autostart celerybeat and celerycam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fabulaws.egg-info/
 *~
 docs/_build/
 .tox
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ fabulaws.egg-info/
 docs/_build/
 .tox
 .python-version
+.vscode

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,6 +5,7 @@ Release History
 
   * Fix bug where users with periods in their usernames were ignored
   * Pass ``--yes`` to ``gpg`` to auto-confirm removal of private key from key ring during dbrestore process
+  * Set ``autostart=true`` for celerybeat and celerycam supervisor processes on worker
 
 * v1.0.7, August 27, 2020
 

--- a/fabulaws/library/wsgiautoscale/templates/supervisor.conf
+++ b/fabulaws/library/wsgiautoscale/templates/supervisor.conf
@@ -43,7 +43,7 @@ command={{ virtualenv_root }}/bin/celery beat --app={{ celery_application }} --s
 directory={{ code_root }}
 user={{ webserver_user }}
 numprocs=1
-autostart=false
+autostart=true
 autorestart=true
 stdout_logfile={{ log_dir }}/celerybeat.log
 redirect_stderr=true
@@ -58,7 +58,7 @@ command={{ virtualenv_root }}/bin/celery events --app={{ celery_application }} -
 directory={{ code_root }}
 user={{ webserver_user }}
 numprocs=1
-autostart=false
+autostart=true
 autorestart=true
 stdout_logfile={{ log_dir }}/celerycam.log
 redirect_stderr=true


### PR DESCRIPTION
These processes should auto start on boot so they resume normal operations if rebooted for security/kernel updates.

Closes #82 